### PR TITLE
made explicit which roles belong where

### DIFF
--- a/contracts/components/Roles.sol
+++ b/contracts/components/Roles.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// These are the roles used in the components of the Forta system, except
+// Forta token itself, that needs to define it's own roles for consistency accross chains
+
 bytes32 constant DEFAULT_ADMIN_ROLE = bytes32(0);
-// Forta
-bytes32 constant ADMIN_ROLE         = keccak256("ADMIN_ROLE");
-bytes32 constant MINTER_ROLE        = keccak256("MINTER_ROLE");
-bytes32 constant WHITELISTER_ROLE   = keccak256("WHITELISTER_ROLE");
-bytes32 constant WHITELIST_ROLE     = keccak256("WHITELIST_ROLE");
+
 // Routing
 bytes32 constant ROUTER_ADMIN_ROLE  = keccak256("ROUTER_ADMIN_ROLE");
 // Base component

--- a/contracts/vesting/escrow/StakingEscrowFactory.sol
+++ b/contracts/vesting/escrow/StakingEscrowFactory.sol
@@ -58,7 +58,7 @@ contract StakingEscrowFactory {
             StakingEscrowUtils.computeSalt(vesting, manager)
         );
         StakingEscrow(instance).initialize(vesting, manager);
-        token.grantRole(WHITELIST_ROLE, instance);
+        token.grantRole(token.WHITELIST_ROLE(), instance);
 
         emit NewStakingEscrow(instance, vesting, manager);
 


### PR DESCRIPTION
Deleted token roles from Roles.sol
Explicitly use the roles defined in FortaCommon when necessary