### PR TITLE
M05: Staked funds might get soft-stuck

### DIFF
--- a/contracts/components/staking/FortaStaking.sol
+++ b/contracts/components/staking/FortaStaking.sol
@@ -41,6 +41,12 @@ interface IRewardReceiver {
  * ERC1155 shares representing active stake are transferable, and can be used in an AMM. Their value is however subject
  * to quick devaluation in case of slashing event for the corresponding subject. Thus, trading of such shares should be
  * be done very carefully.
+ * 
+ * WARNING: To stake from another smart contract (smart contract wallets included), it must be fully ERC1155 compatible,
+ * implementing ERC1155Receiver. If not, minting of active and inactive shares will fail.
+ * Do not deposit on the constructor if you don't implement ERC1155Receiver. During the construction, the miniting will
+ * succeed but you will not be able to withdraw or mint new shares from the contract. If this happens, transfer your
+ * shares to an EOA or fully ERC1155 compatible contract.
  */
 contract FortaStaking is BaseComponentUpgradeable, ERC1155SupplyUpgradeable, IStakeController {
     using Distributions for Distributions.Balances;
@@ -197,6 +203,12 @@ contract FortaStaking is BaseComponentUpgradeable, ERC1155SupplyUpgradeable, ISt
      * @dev Deposit `stakeValue` tokens for a given `subject`, and mint the corresponding shares.
      * NOTE: Subject type is necessary because we can't infer subject ID uniqueness between scanners, agents, etc
      * Emits a ERC1155.TransferSingle event and StakeDeposited (to allow accounting per subject type)
+     *
+     * WARNING: To stake from another smart contract (smart contract wallets included), it must be fully ERC1155 compatible,
+     * implementing ERC1155Receiver. If not, minting of active and inactive shares will fail.
+     * Do not deposit on the constructor if you don't implement ERC1155Receiver. During the construction, the miniting will
+     * succeed but you will not be able to withdraw or mint new shares from the contract. If this happens, transfer your
+     * shares to an EOA or fully ERC1155 compatible contract.
      */
     function deposit(uint8 subjectType, uint256 subject, uint256 stakeValue)
         public


### PR DESCRIPTION
Added comments warning about this:

>When minting these ERC1155, the _doSafeTransferAcceptanceCheck hook will get triggered and it
would check if the destinatary is a ERC1155Receiver implementer or not when it detects that the
address has code in it.
However, if the minting process happens during the constructor of a non-fully compatible ERC1155
wallet, the FortaStaking contract would treat the destinatary as a regular EOA during the minting
process. Then, once it is deployed, the wallet will not be able to mint new shares due to the same
_doSafeTransferAcceptanceCheck hook as it will get triggered, failing at the same validation that was
skipped on the first deposit.
This means that when the wallet starts the process to withdraw the assets, the transaction will fail
during the minting of inactive shares. Nevertheless, the user may transfer those active shares to a fully
compatible wallet to then initiate the withdrawal process once again.

More warnings will be added to the public docs on release.