### PR TITLE
N08: Naming issues

### DIFF
--- a/contracts/components/dispatch/Dispatch.sol
+++ b/contracts/components/dispatch/Dispatch.sol
@@ -43,30 +43,30 @@ contract Dispatch is BaseComponentUpgradeable {
         return _scanners;
     }
 
-    function agentsFor(uint256 scannerId) public view returns (uint256) {
+    function numAgentsFor(uint256 scannerId) public view returns (uint256) {
         return scannerToAgents[scannerId].length();
     }
 
-    function scannersFor(uint256 agentId) public view returns (uint256) {
+    function numScannersFor(uint256 agentId) public view returns (uint256) {
         return agentToScanners[agentId].length();
     }
 
-    function agentsAt(uint256 scannerId, uint256 pos) public view returns (uint256) {
+    function agentAt(uint256 scannerId, uint256 pos) public view returns (uint256) {
         return scannerToAgents[scannerId].at(pos);
     }
 
     function agentRefAt(uint256 scannerId, uint256 pos) external view returns (uint256 agentId, bool enabled, uint256 agentVersion, string memory metadata, uint256[] memory chainIds) {
-        agentId = agentsAt(scannerId, pos);
+        agentId = agentAt(scannerId, pos);
         enabled = _agents.isEnabled(agentId);
         (agentVersion, metadata, chainIds) = _agents.getAgent(agentId);
     }
 
-    function scannersAt(uint256 agentId, uint256 pos) public view returns (uint256) {
+    function scannerAt(uint256 agentId, uint256 pos) public view returns (uint256) {
         return agentToScanners[agentId].at(pos);
     }
 
     function scannerRefAt(uint256 agentId, uint256 pos) external view returns (uint256 scannerId, bool enabled) {
-        scannerId = scannersAt(agentId, pos);
+        scannerId = scannerAt(agentId, pos);
         enabled   = _scanners.isEnabled(agentId);
     }
 

--- a/contracts/vesting/VestingWalletV2.sol
+++ b/contracts/vesting/VestingWalletV2.sol
@@ -116,7 +116,7 @@ contract VestingWalletV2 is VestingWallet {
     /**
      * Admin operations
      */
-    function setHistoricalBalanceBridged(uint256 value)
+    function setHistoricalBalanceMin(uint256 value)
         public
         onlyOwner()
     {
@@ -124,10 +124,10 @@ contract VestingWalletV2 is VestingWallet {
         historicalBalanceMin = value;
     }
 
-    function updateHistoricalBalanceBridged(int256 update)
+    function updateHistoricalBalanceMin(int256 update)
         public
         onlyOwner()
     {
-        setHistoricalBalanceBridged((historicalBalanceMin.toInt256() + update).toUint256());
+        setHistoricalBalanceMin((historicalBalanceMin.toInt256() + update).toUint256());
     }
 }

--- a/test/components/dispatcher.test.js
+++ b/test/components/dispatcher.test.js
@@ -109,7 +109,7 @@ describe('Dispatcher', function () {
       }
 
       await Promise.all([
-        this.dispatch.agentsFor(this.SCANNER_ID),
+        this.dispatch.numAgentsFor(this.SCANNER_ID),
         this.dispatch.estimateGas.scannerHash(this.SCANNER_ID),
       ]).then(([ count, cost ]) => console.log(`scannerHash gas cost with ${count.toString()} agents: ${cost.toString()}`));
     }


### PR DESCRIPTION
- I think having 2 `getNonce` methods with different parameters is a valid example of static polymorphism. The possible confusion will be mitigated by adding NatSpec in [N07]
- As we said in the previous review, we signal that a contract is upgradeable when they inherit from `BaseContractUpgradeable`  (or other `Upgradeables` in `Router`'s case). Adding the suffix to every contract may be very noisy, especially when using long contract names.
- The other changes are included, thanks.