### PR TITLE
Scripts and tasks to help getting and indentifying share ids.

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,6 +7,7 @@ require('solidity-docgen');
 require('hardhat-gas-reporter');
 require('@openzeppelin/hardhat-upgrades');
 require('@openzeppelin/hardhat-defender');
+const { task } = require('hardhat/config')
 const { relative } = require('path');
 
 const argv = require('yargs/yargs')().env('').argv;
@@ -17,6 +18,13 @@ task('compare-storage', 'Prints storage layout of 2 implementations')
     .setAction(async (taskArgs) => {
         const storageToTable = require('./scripts/storage-to-table');
         storageToTable({ old: taskArgs.old, new: taskArgs.new });
+    });
+
+task('forta:share-type', 'Checks if a list of shares is active or inactive')
+    .addParam('ids', 'Array of ids')
+    .setAction(async (taskArgs) => {
+        const getShareTypes = require('./scripts/get-share-types');
+        getShareTypes({ shareIds: taskArgs.ids.split(',') });
     });
 
 module.exports = {};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@openzeppelin/hardhat-upgrades": "^1.19.0",
     "@truffle/hdwallet-provider": "^1.7.0",
     "axios": "^0.27.2",
+    "block-by-date-ethers": "^1.0.0",
     "chai": "^4.3.4",
     "conf": "^10.0.2",
     "convert-csv-to-json": "^1.3.3",

--- a/scripts/get-share-types.js
+++ b/scripts/get-share-types.js
@@ -6,15 +6,21 @@ const SHARE_IDS = [
     '99050038579047722081472362029662902001055019802069199823963888849172082939904',
 ];
 
-async function main() {
-    SHARE_IDS.forEach((share) => {
-        console.log(share);
-        console.log('isActive', stakingUtils.isActive(share));
-    });
+async function getShareTypes(config = {}) {
+    const ids = config.shareIds ?? SHARE_IDS;
+    const shares = ids
+        .map((share) => {
+            return {
+                shareId: share,
+                isActive: stakingUtils.isActive(share),
+            };
+        })
+        .sort((a, b) => (a.isActive ? -1 : 1));
+    console.table(shares);
 }
 
 if (require.main === module) {
-    main()
+    getShareTypes()
         .then(() => process.exit(0))
         .catch((error) => {
             console.error(error);
@@ -22,4 +28,4 @@ if (require.main === module) {
         });
 }
 
-module.exports = main;
+module.exports = getShareTypes;

--- a/scripts/get-subjects-from-share-ids.js
+++ b/scripts/get-subjects-from-share-ids.js
@@ -1,31 +1,12 @@
 const { ethers, network } = require('hardhat');
 const DEBUG = require('debug')('forta');
 const utils = require('./utils');
-const EthDater = require('block-by-date-ethers');
+const stakingUtils = require('./utils/staking.js');
+
 const fs = require('fs');
 
-const INITIAL_DATE = '2022-06-14T00:00:00Z';
-const END_DATE = '2022-06-14T23:59:59Z';
-
-async function logsForInterval(initialBlock, endBlock, contract, filters) {
-    let logs = filters.map(() => []);
-    const blockInterval = 5000;
-    for (let i = initialBlock.block; i <= endBlock.block; i += blockInterval) {
-        const fromBlock = i;
-        const toBlock = Math.min(endBlock.block, i + blockInterval);
-        console.log(fromBlock, '-', toBlock);
-        for (let j = 0; j < filters.length; j++) {
-            const result = await contract.queryFilter(filters[j], fromBlock, toBlock);
-            logs[j] = [...logs[j], ...result];
-        }
-    }
-    return Array.from(new Set(logs));
-}
-
-async function getShareId(provider, txHash) {
-    const receipt = await provider.getTransactionReceipt(txHash);
-    console.log(receipt.logs);
-}
+const INITIAL_DATE = '2022-03-28T00:00:00Z';
+const END_DATE = '2022-04-10T00:00:00Z'; //new Date().toISOString();
 
 async function getClaimStats(config = {}) {
     const initialDate = config.startDate ?? INITIAL_DATE;
@@ -49,33 +30,32 @@ async function getClaimStats(config = {}) {
         }).map((entry) => Promise.all(entry))
     ).then(Object.fromEntries);
 
-    const dater = new EthDater(provider);
-    const initialBlock = await dater.getDate(initialDate, true);
-    console.log(initialBlock);
-    const endBlock = await dater.getDate(endDate, true);
-    console.log(endBlock);
-    const stakeDepositFilter = contracts.staking.filters.StakeDeposited(null, null);
-    const transferSingleFilter = contracts.staking.filters.TransferSingle(null, ethers.constants.AddressZero, null);
+    const filters = {};
+    filters['stakeDeposit'] = contracts.staking.filters.StakeDeposited(null, null);
+    //filters['shareMinting'] = contracts.staking.filters.TransferSingle(null, ethers.constants.AddressZero, null);
 
-    const depositLogs = await logsForInterval(initialBlock, endBlock, contracts.staking, [stakeDepositFilter, transferSingleFilter]);
+    const depositLogs = await utils.getEventsForTimeInterval(provider, initialDate, endDate, contracts.staking, filters);
+    console.log(depositLogs);
     let deposits = await Promise.all(
-        depositLogs.map(async (log) => {
+        depositLogs.stakeDeposit.map(async (log) => {
             console.log(log);
             return {
-                blockNumber: log[0].blockNumber,
-                timestamp: new Date((await provider.getBlock(log[0].blockNumber)).timestamp).toUTCString(),
+                // blockNumber: log.args.blockNumber,
+                // timestamp: new Date((await provider.getBlock(log.args.blockNumber)).timestamp).toUTCString(),
                 subjectType: log.args.subjectType,
                 subject: log.args.subject.toString(),
+                activeSharesId: stakingUtils.subjectToActive(log.args.subjectType, log.args.subject.toString()).toString(),
+                inactiveSharesId: stakingUtils.subjectToInactive(log.args.subjectType, log.args.subject.toString()).toString(),
             };
         })
     );
+    deposits = Array.from(new Set(deposits));
     console.table(deposits);
-    /*
+
     console.log('Writing results to:');
-    const path = `./scripts/data/claims-${initialBlock.date}-${endBlock.date}.csv`;
+    const path = `./scripts/data/share-ids-${initialDate}-${endDate}.json`;
     console.log(path);
-    fs.writeFileSync(path, await converter.json2csvAsync(claims));
-    */
+    fs.writeFileSync(path, JSON.stringify(deposits));
 }
 
 if (require.main === module) {

--- a/scripts/get-subjects-from-share-ids.js
+++ b/scripts/get-subjects-from-share-ids.js
@@ -1,0 +1,90 @@
+const { ethers, network } = require('hardhat');
+const DEBUG = require('debug')('forta');
+const utils = require('./utils');
+const EthDater = require('block-by-date-ethers');
+const fs = require('fs');
+
+const INITIAL_DATE = '2022-06-14T00:00:00Z';
+const END_DATE = '2022-06-14T23:59:59Z';
+
+async function logsForInterval(initialBlock, endBlock, contract, filters) {
+    let logs = filters.map(() => []);
+    const blockInterval = 5000;
+    for (let i = initialBlock.block; i <= endBlock.block; i += blockInterval) {
+        const fromBlock = i;
+        const toBlock = Math.min(endBlock.block, i + blockInterval);
+        console.log(fromBlock, '-', toBlock);
+        for (let j = 0; j < filters.length; j++) {
+            const result = await contract.queryFilter(filters[j], fromBlock, toBlock);
+            logs[j] = [...logs[j], ...result];
+        }
+    }
+    return Array.from(new Set(logs));
+}
+
+async function getShareId(provider, txHash) {
+    const receipt = await provider.getTransactionReceipt(txHash);
+    console.log(receipt.logs);
+}
+
+async function getClaimStats(config = {}) {
+    const initialDate = config.startDate ?? INITIAL_DATE;
+    const endDate = config.endDate ?? END_DATE;
+    const provider = await utils.getDefaultProvider();
+    let deployer = ethers.Wallet.fromMnemonic(process.env[`${network.name.toUpperCase()}_MNEMONIC`]);
+    deployer = deployer.connect(provider);
+    // await utils.getDefaultDeployer(provider);
+
+    const { name, chainId } = await provider.getNetwork();
+
+    const deployment = require(`./.cache-${chainId}`);
+
+    DEBUG(`Network:  ${name} (${chainId})`);
+    DEBUG(`Deployer: ${deployer.address}`);
+    DEBUG('----------------------------------------------------');
+
+    const contracts = await Promise.all(
+        Object.entries({
+            staking: utils.attach('FortaStaking', deployment.staking.address).then((contract) => contract.connect(deployer)),
+        }).map((entry) => Promise.all(entry))
+    ).then(Object.fromEntries);
+
+    const dater = new EthDater(provider);
+    const initialBlock = await dater.getDate(initialDate, true);
+    console.log(initialBlock);
+    const endBlock = await dater.getDate(endDate, true);
+    console.log(endBlock);
+    const stakeDepositFilter = contracts.staking.filters.StakeDeposited(null, null);
+    const transferSingleFilter = contracts.staking.filters.TransferSingle(null, ethers.constants.AddressZero, null);
+
+    const depositLogs = await logsForInterval(initialBlock, endBlock, contracts.staking, [stakeDepositFilter, transferSingleFilter]);
+    let deposits = await Promise.all(
+        depositLogs.map(async (log) => {
+            console.log(log);
+            return {
+                blockNumber: log[0].blockNumber,
+                timestamp: new Date((await provider.getBlock(log[0].blockNumber)).timestamp).toUTCString(),
+                subjectType: log.args.subjectType,
+                subject: log.args.subject.toString(),
+            };
+        })
+    );
+    console.table(deposits);
+    /*
+    console.log('Writing results to:');
+    const path = `./scripts/data/claims-${initialBlock.date}-${endBlock.date}.csv`;
+    console.log(path);
+    fs.writeFileSync(path, await converter.json2csvAsync(claims));
+    */
+}
+
+if (require.main === module) {
+    getClaimStats()
+        .then(() => process.exit(0))
+        .catch((error) => {
+            console.error(error);
+            process.exit(1);
+        });
+}
+
+module.exports = getClaimStats;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,13 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
+block-by-date-ethers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/block-by-date-ethers/-/block-by-date-ethers-1.0.0.tgz#0e8a2b9a739aced6cb14c354cd88acf6d39ccb39"
+  integrity sha512-Ct2Qt05ihpKR37e8XXOxwwZgDDMu7MRnyXLw96wBhTPe1S1/bOc2jxHNehQ3eV2lhnUvvUAE+sO4w749JO6Axg==
+  dependencies:
+    moment "^2.27.0"
+
 bluebird@^3.4.7, bluebird@^3.5.0, bluebird@^3.5.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -8614,6 +8621,11 @@ mock-fs@^4.1.0:
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
   integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
+
+moment@^2.27.0:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Task `forta:share-type` to know if shares ids are active or inactive. Use:

```npx hardhat forta:share-type --ids <share_id1>,<share_id2>...<share_idn> ```

- Script `get-subjects-from-share-ids`

Added `getEventsForTimeInterval` to `utils.js`, that uses [this library](https://www.npmjs.com/package/block-by-date-ethers) to get block numbers and iterate every 5k blocks, applying event filters to a contract.

We use it here to get all the `StakeDeposited` events between 2 dates and calculate all share ids, storing them in
`./scripts/data/share-ids-${initialDate}-${endDate}.json`

Usage: Edit the dates in the file, then
```npx hardhat --network polygon run scripts/get-subjects-from-share-ids.js```

