### PR TITLE
Added warning to ForwardedContext constructor

### DIFF
--- a/contracts/components/utils/ForwardedContext.sol
+++ b/contracts/components/utils/ForwardedContext.sol
@@ -14,6 +14,9 @@ abstract contract ForwardedContext is ContextUpgradeable {
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address trustedForwarder) {
+        // WARNING: do not set this address to other than a deployed Forwarder instance.
+        // Forwarder is critical infrastructure with priviledged address, it is safe for the limited
+        // functionality of the Forwarder contract, any other EOA or contract could be a security issue.
         _trustedForwarder = trustedForwarder;
     }
 


### PR DESCRIPTION
Highlight the importance of setting the Forwarder address correctly.