### PR TITLE
Fix activeShares transfer

### DIFF
--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -151,17 +151,23 @@ type StakeThreshold @entity {
 
 type Subject @entity {
   id: ID!
+  subjectId: BigInt
   subjectType: Int
-  activeSharesId: Int
+  activeSharesId: String
   activeShares: BigInt
   activeStake: BigInt
-  inactiveSharesId: Int
+  inactiveSharesId: String
   inactiveShares: BigInt
   inactiveStake: BigInt
   isFrozen: Boolean
   slashedTotal: Int
   stakes: [Stake!]! @derivedFrom(field: "subject")
   stakeDepositedEvents: [StakeDepositEvent!] @derivedFrom(field: "subject")
+}
+
+type SharesID @entity {
+  id: ID!
+  subject: Subject!
 }
 
 type Slash @entity {
@@ -174,7 +180,7 @@ type Slash @entity {
 
 type Reward @entity {
   id: ID!
-  activeSharesId: Int
+  activeSharesId: String
   subjectType: Int
   subjectId: String
   staker: Staker!

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -103,4 +103,7 @@ dataSources:
           handler: handleSlashed
         - event: Froze(indexed uint8,indexed uint256,indexed address,bool)
           handler: handleFroze
+        - event: TransferSingle(indexed address,indexed address,indexed
+            address,uint256,uint256)
+          handler: handleTransferSingle
       file: ./src/datasources/FortaStaking.ts


### PR DESCRIPTION
This PR adds support for `TransferSingle` events when activeShares are transfered from one wallet to another. 