### PR TITLE
Fix scanner pools shutting down on scanner registration and enabling.

### DIFF
--- a/contracts/components/staking/allocation/IStakeAllocator.sol
+++ b/contracts/components/staking/allocation/IStakeAllocator.sol
@@ -23,5 +23,7 @@ interface IStakeAllocator {
     ) external;
 
     function allocatedStakePerManaged(uint8 subjectType, uint256 subject) external view returns (uint256);
+    function allocatedManagedStake(uint8 subjectType, uint256 subject) external view returns (uint256);
+    function allocateOwnStake(uint8 subjectType, uint256 subject, uint256 amount) external;
     function didTransferShares(uint256 sharesId, uint8 subjectType, address from, address to, uint256 sharesAmount) external;
 }

--- a/contracts/components/staking/allocation/IStakeAllocator.sol
+++ b/contracts/components/staking/allocation/IStakeAllocator.sol
@@ -22,8 +22,10 @@ interface IStakeAllocator {
         uint256 sharesAmount
     ) external;
 
+    function allocatedStakeFor(uint8 subjectType, uint256 subject) external view returns (uint256);
     function allocatedStakePerManaged(uint8 subjectType, uint256 subject) external view returns (uint256);
-    function allocatedManagedStake(uint8 subjectType, uint256 subject) external view returns (uint256);
+    function unallocatedStakeFor(uint8 subjectType, uint256 subject) external view returns (uint256);
+
     function allocateOwnStake(uint8 subjectType, uint256 subject, uint256 amount) external;
     function didTransferShares(uint256 sharesId, uint8 subjectType, address from, address to, uint256 sharesAmount) external;
 }

--- a/contracts/components/staking/allocation/StakeAllocator.sol
+++ b/contracts/components/staking/allocation/StakeAllocator.sol
@@ -71,13 +71,20 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
     /// Total allocated stake in all managed subjects, both from delegated and delegator. Only returns values from
     /// DELEGATED types, else 0.
     function allocatedManagedStake(uint8 subjectType, uint256 subject) public view returns (uint256) {
+        //console.log("---------allocatedManagedStake subjectType %d shareId %s", subjectType, FortaStakingUtils.subjectToActive(subjectType, subject));
         if (getSubjectTypeAgency(subjectType) == SubjectStakeAgency.DELEGATED) {
+            //console.log(
+            //    "%d + %d",
+            //    _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(subjectType, subject)),
+            //    _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(getDelegatorSubjectType(subjectType), subject))
+            //);
             return
                 _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(subjectType, subject)) +
                 _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(getDelegatorSubjectType(subjectType), subject));
         }
         return 0;
     }
+    
 
     /// Returns allocatedManagedStake (own + delegator's) in DELEGATED / total managed subjects, or 0 if not DELEGATED
     function allocatedStakePerManaged(uint8 subjectType, uint256 subject) external view returns (uint256) {

--- a/contracts/components/staking/allocation/StakeAllocator.sol
+++ b/contracts/components/staking/allocation/StakeAllocator.sol
@@ -11,6 +11,7 @@ import "../stake_subjects/IStakeSubjectGateway.sol";
 import "../../BaseComponentUpgradeable.sol";
 import "../../../tools/Distributions.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
+import "hardhat/console.sol";
 
 /**
  * This contract also manages the allocation of stake. See SubjectTypeValidator.sol for in depth explanation of Subject Agency
@@ -190,10 +191,11 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
         if (_unallocatedStake.balanceOf(activeSharesId) < amount) revert AmountTooLarge(amount, _unallocatedStake.balanceOf(activeSharesId));
         (int256 extra, uint256 max) = _allocationIncreaseChecks(subjectType, subject, getSubjectTypeAgency(subjectType), allocator, amount);
         if (extra > 0) revert AmountTooLarge(amount, max);
+        console.log("allocate before subjectType %d , allocated %d, unallocated %d", subjectType, _allocatedStake.balanceOf(activeSharesId), _unallocatedStake.balanceOf(activeSharesId));
         _allocatedStake.mint(activeSharesId, amount);
         _unallocatedStake.burn(activeSharesId, amount);
         _rewardsDistributor.didAllocate(subjectType, subject, amount, 0, address(0));
-
+        console.log("allocate after subjectType %d , allocated %d, unallocated %d", subjectType, _allocatedStake.balanceOf(activeSharesId), _unallocatedStake.balanceOf(activeSharesId));
         emit AllocatedStake(subjectType, subject, true, amount, _allocatedStake.balanceOf(activeSharesId));
         emit UnallocatedStake(subjectType, subject, false, amount, _unallocatedStake.balanceOf(activeSharesId));
     }
@@ -211,9 +213,12 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
     ) private {
         uint256 activeSharesId = FortaStakingUtils.subjectToActive(subjectType, subject);
         if (_allocatedStake.balanceOf(activeSharesId) < amount) revert AmountTooLarge(amount, _allocatedStake.balanceOf(activeSharesId));
+        console.log("unallocate bdefore subjectType %d , allocated %d, unallocated %d", subjectType, _allocatedStake.balanceOf(activeSharesId), _unallocatedStake.balanceOf(activeSharesId));
+
         _allocatedStake.burn(activeSharesId, amount);
         _unallocatedStake.mint(activeSharesId, amount);
         _rewardsDistributor.didUnallocate(subjectType, subject, amount, 0, address(0));
+        console.log("unallocate after subjectType %d , allocated %d, unallocated %d", subjectType, _allocatedStake.balanceOf(activeSharesId), _unallocatedStake.balanceOf(activeSharesId));
         emit AllocatedStake(subjectType, subject, false, amount, _allocatedStake.balanceOf(activeSharesId));
         emit UnallocatedStake(subjectType, subject, true, amount, _unallocatedStake.balanceOf(activeSharesId));
     }
@@ -242,6 +247,8 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
         if (agency != SubjectStakeAgency.DELEGATED && agency != SubjectStakeAgency.DELEGATOR) {
             return;
         }
+        console.log("deposit before subjectType %d , allocated %d, unallocated %d", subjectType, _allocatedStake.balanceOf(activeSharesId), _unallocatedStake.balanceOf(activeSharesId));
+
         (int256 extra, ) = _allocationIncreaseChecks(subjectType, subject, agency, allocator, stakeAmount);
         if (extra > 0) {
             _allocatedStake.mint(activeSharesId, stakeAmount - uint256(extra));
@@ -254,6 +261,8 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
             _rewardsDistributor.didAllocate(subjectType, subject, stakeAmount, sharesAmount, allocator);
             emit AllocatedStake(subjectType, subject, true, stakeAmount, _allocatedStake.balanceOf(activeSharesId));
         }
+        console.log("deposit after subjectType %d , allocated %d, unallocated %d", subjectType, _allocatedStake.balanceOf(activeSharesId), _unallocatedStake.balanceOf(activeSharesId));
+
     }
 
     /**

--- a/contracts/components/staking/allocation/StakeAllocator.sol
+++ b/contracts/components/staking/allocation/StakeAllocator.sol
@@ -71,13 +71,7 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
     /// Total allocated stake in all managed subjects, both from delegated and delegator. Only returns values from
     /// DELEGATED types, else 0.
     function allocatedManagedStake(uint8 subjectType, uint256 subject) public view returns (uint256) {
-        //console.log("---------allocatedManagedStake subjectType %d shareId %s", subjectType, FortaStakingUtils.subjectToActive(subjectType, subject));
         if (getSubjectTypeAgency(subjectType) == SubjectStakeAgency.DELEGATED) {
-            //console.log(
-            //    "%d + %d",
-            //    _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(subjectType, subject)),
-            //    _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(getDelegatorSubjectType(subjectType), subject))
-            //);
             return
                 _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(subjectType, subject)) +
                 _allocatedStake.balanceOf(FortaStakingUtils.subjectToActive(getDelegatorSubjectType(subjectType), subject));
@@ -88,7 +82,7 @@ contract StakeAllocator is BaseComponentUpgradeable, SubjectTypeValidator, IStak
 
     /// Returns allocatedManagedStake (own + delegator's) in DELEGATED / total managed subjects, or 0 if not DELEGATED
     function allocatedStakePerManaged(uint8 subjectType, uint256 subject) external view returns (uint256) {
-        if (getSubjectTypeAgency(subjectType) != SubjectStakeAgency.DELEGATED) {
+        if (getSubjectTypeAgency(subjectType) != SubjectStakeAgency.DELEGATED || _subjectGateway.totalManagedSubjects(subjectType, subject) == 0) {
             return 0;
         }
         return allocatedManagedStake(subjectType, subject) / _subjectGateway.totalManagedSubjects(subjectType, subject);

--- a/contracts/components/staking/stake_subjects/StakeSubjectGateway.sol
+++ b/contracts/components/staking/stake_subjects/StakeSubjectGateway.sol
@@ -151,6 +151,7 @@ contract StakeSubjectGateway is BaseComponentUpgradeable, SubjectTypeValidator, 
         return IStakeSubject(_stakeSubjects[subjectType]).isRegistered(subject);
     }
 
+    /// Returns true if allocator owns the subject, or is the subject contract itself
     function canManageAllocation(uint8 subjectType, uint256 subject, address allocator) external view returns (bool) {
         SubjectStakeAgency agency = getSubjectTypeAgency(subjectType);
         if (agency != SubjectStakeAgency.DELEGATOR && agency != SubjectStakeAgency.DELEGATED) {
@@ -159,7 +160,7 @@ contract StakeSubjectGateway is BaseComponentUpgradeable, SubjectTypeValidator, 
         if (address(0) == _stakeSubjects[subjectType]) {
             return false;
         }
-        return IStakeSubject(_stakeSubjects[subjectType]).ownerOf(subject) == allocator;
+        return IStakeSubject(_stakeSubjects[subjectType]).ownerOf(subject) == allocator || _stakeSubjects[subjectType] == allocator;
     }
 
     function ownerOf(uint8 subjectType, uint256 subject) external view returns (address) {

--- a/test/components/dispatcher.test.js
+++ b/test/components/dispatcher.test.js
@@ -20,7 +20,11 @@ describe('Dispatcher', function () {
         this.SCANNER_SUBJECT_ID = BigNumber.from(this.SCANNER_ID);
         // Create Agent and Scanner
         await this.agents.createAgent(this.AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4, 5]);
+        await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.AGENT, this.AGENT_ID, '100');
+
         await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
+        await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.NODE_RUNNER, 1, '100');
+
         const { chainId } = await ethers.provider.getNetwork();
         verifyingContractInfo = {
             address: this.contracts.nodeRunners.address,
@@ -35,12 +39,8 @@ describe('Dispatcher', function () {
             timestamp: (await ethers.provider.getBlock('latest')).timestamp,
         };
         const signature = await signERC712ScannerRegistration(verifyingContractInfo, registration, this.accounts.scanner);
-
         await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
 
-        // Stake
-        await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.NODE_RUNNER, 1, '100');
-        await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.AGENT, this.AGENT_ID, '100');
     });
 
     it('protected', async function () {

--- a/test/components/noderunners.test.js
+++ b/test/components/noderunners.test.js
@@ -5,7 +5,7 @@ const { prepare } = require('../fixture');
 const { BigNumber } = require('@ethersproject/bignumber');
 const { signERC712ScannerRegistration } = require('../../scripts/utils/scannerRegistration');
 
-let SCANNER_ADDRESS_1, scanner1Registration, scanner1Signature, verifyingContractInfo;
+let SCANNER_ADDRESS_1, scanner1Registration, scanner1Signature, SCANNER_ADDRESS_2, scanner2Registration, scanner2Signature, verifyingContractInfo;
 describe('Node Runner Registry', function () {
     // TODO Stake related stuff
     prepare({ stake: { scanners: { min: '100', max: '500', activated: true } } });
@@ -28,6 +28,15 @@ describe('Node Runner Registry', function () {
         };
 
         scanner1Signature = await signERC712ScannerRegistration(verifyingContractInfo, scanner1Registration, this.accounts.scanner);
+        SCANNER_ADDRESS_2 = this.accounts.user2.address;
+        scanner2Registration = {
+            scanner: SCANNER_ADDRESS_2,
+            nodeRunnerId: 1,
+            chainId: 1,
+            metadata: 'metadata2',
+            timestamp: (await ethers.provider.getBlock('latest')).timestamp,
+        };
+        scanner2Signature = await signERC712ScannerRegistration(verifyingContractInfo, scanner2Registration, this.accounts.user2);
     });
 
     it('register node runner', async function () {
@@ -50,38 +59,51 @@ describe('Node Runner Registry', function () {
         expect(await this.nodeRunners.monitoredChainId(2)).to.be.equal(44);
     });
 
-    it('register scanner', async function () {
-        const SCANNER_ADDRESS = this.accounts.scanner.address;
-        const SCANNER_ADDRESS_2 = this.accounts.user2.address;
+    describe('Register scanner', function () {
+        it('registers scanners', async function () {
+            const SCANNER_ADDRESS = this.accounts.scanner.address;
+            await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
 
-        await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
-        await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature))
-            .to.emit(this.nodeRunners, 'ScannerUpdated')
-            .withArgs(SCANNER_ADDRESS, 1, 'metadata', 1);
-        const scanner2Registration = {
-            scanner: SCANNER_ADDRESS_2,
-            nodeRunnerId: 1,
-            chainId: 1,
-            metadata: 'metadata2',
-            timestamp: (await ethers.provider.getBlock('latest')).timestamp,
-        };
-        const scanner2Signature = await signERC712ScannerRegistration(verifyingContractInfo, scanner2Registration, this.accounts.user2);
-        await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner2Registration, scanner2Signature))
-            .to.emit(this.nodeRunners, 'ScannerUpdated')
-            .withArgs(SCANNER_ADDRESS_2, 1, 'metadata2', 1);
+            await this.staking.connect(this.accounts.user1).deposit(2, 1, '200');
+            expect(await this.stakeAllocator.unallocatedStakeFor(2, 1)).to.eq('200');
+            expect(await this.stakeAllocator.allocatedStakeFor(2, 1)).to.eq('0');
+            expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('0');
+            await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature))
+                .to.emit(this.nodeRunners, 'ScannerUpdated')
+                .withArgs(SCANNER_ADDRESS, 1, 'metadata', 1);
+            expect(await this.stakeAllocator.unallocatedStakeFor(2, 1)).to.eq('0');
+            expect(await this.stakeAllocator.allocatedStakeFor(2, 1)).to.eq('200');
+            expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('200');
 
-        expect(await this.nodeRunners.getScanner(SCANNER_ADDRESS)).to.be.deep.equal([true, false, BigNumber.from(1), BigNumber.from(1), 'metadata']);
+            await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner2Registration, scanner2Signature))
+                .to.emit(this.nodeRunners, 'ScannerUpdated')
+                .withArgs(SCANNER_ADDRESS_2, 1, 'metadata2', 1);
+            expect(await this.stakeAllocator.unallocatedStakeFor(2, 1)).to.eq('0');
+            expect(await this.stakeAllocator.allocatedStakeFor(2, 1)).to.eq('200');
+            expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('100');
 
-        expect(await this.nodeRunners.isScannerRegistered(SCANNER_ADDRESS)).to.be.equal(true);
-        expect(await this.nodeRunners.registeredScannerAddressAtIndex(1, 0)).to.be.equal(SCANNER_ADDRESS);
+            expect(await this.nodeRunners.getScanner(SCANNER_ADDRESS)).to.be.deep.equal([true, false, BigNumber.from(1), BigNumber.from(1), 'metadata']);
+            expect(await this.nodeRunners.isScannerRegistered(SCANNER_ADDRESS)).to.be.equal(true);
+            expect(await this.nodeRunners.registeredScannerAddressAtIndex(1, 0)).to.be.equal(SCANNER_ADDRESS);
+            expect(await this.nodeRunners.getScanner(SCANNER_ADDRESS_2)).to.be.deep.equal([true, false, BigNumber.from(1), BigNumber.from(1), 'metadata2']);
+            expect(await this.nodeRunners.isScannerRegistered(SCANNER_ADDRESS_2)).to.be.equal(true);
+            expect(await this.nodeRunners.registeredScannerAddressAtIndex(1, 1)).to.be.equal(SCANNER_ADDRESS_2);
+            expect(await this.nodeRunners.isScannerRegistered(this.accounts.user3.address)).to.be.equal(false);
+            expect(await this.nodeRunners.totalScannersRegistered(1)).to.be.equal(2);
+        });
 
-        expect(await this.nodeRunners.getScanner(SCANNER_ADDRESS_2)).to.be.deep.equal([true, false, BigNumber.from(1), BigNumber.from(1), 'metadata2']);
-        expect(await this.nodeRunners.isScannerRegistered(SCANNER_ADDRESS_2)).to.be.equal(true);
-        expect(await this.nodeRunners.registeredScannerAddressAtIndex(1, 1)).to.be.equal(SCANNER_ADDRESS_2);
+        it('fails to register scanner if not enough allocated stake', async function () {
+            const SCANNER_ADDRESS = this.accounts.scanner.address;
 
-        expect(await this.nodeRunners.isScannerRegistered(this.accounts.user3.address)).to.be.equal(false);
+            await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
+            await this.staking.connect(this.accounts.user1).deposit(2, 1, '100');
 
-        expect(await this.nodeRunners.totalScannersRegistered(1)).to.be.equal(2);
+            await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature))
+                .to.emit(this.nodeRunners, 'ScannerUpdated')
+                .withArgs(SCANNER_ADDRESS, 1, 'metadata', 1);
+
+            await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner2Registration, scanner2Signature)).to.be.revertedWith('ActionShutsDownPool');
+        });
     });
 
     describe('migration', function () {
@@ -184,6 +206,8 @@ describe('Node Runner Registry', function () {
         const SCANNER_ADDRESS = this.accounts.scanner.address;
 
         await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
+        await this.staking.connect(this.accounts.user1).deposit(2, 1, '100');
+
         await expect(this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature))
             .to.emit(this.nodeRunners, 'ScannerUpdated')
             .withArgs(SCANNER_ADDRESS, 1, 'metadata', 1);
@@ -202,6 +226,8 @@ describe('Node Runner Registry', function () {
         const SCANNER_ADDRESS = this.accounts.scanner.address;
 
         await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
+        await this.staking.connect(this.accounts.user1).deposit(2, 1, '200');
+
         await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature);
         await expect(this.nodeRunners.connect(this.accounts.user1).updateScannerMetadata(SCANNER_ADDRESS, '333'))
             .to.emit(this.nodeRunners, 'ScannerUpdated')
@@ -215,6 +241,8 @@ describe('Node Runner Registry', function () {
         const WRONG_SCANNER_ADDRESS = this.accounts.admin.address;
 
         await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
+        await this.staking.connect(this.accounts.user1).deposit(2, 1, '200');
+
         await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature);
 
         await expect(this.nodeRunners.connect(this.accounts.user1).updateScannerMetadata(WRONG_SCANNER_ADDRESS, '333')).to.be.revertedWith(
@@ -278,11 +306,11 @@ describe('Node Runner Registry', function () {
         });
     });
 
-    describe.skip('enable and disable', async function () {
+    describe('enable and disable', async function () {
         beforeEach(async function () {
-            await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner();
+            await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(1);
+            await this.staking.connect(this.accounts.user1).deposit(2, 1, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner1Registration, scanner1Signature);
-            // await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.SCANNER, SCANNER_ADDRESS, '100');
         });
 
         describe('manager', async function () {
@@ -302,21 +330,28 @@ describe('Node Runner Registry', function () {
 
             it('re-enable', async function () {
                 const SCANNER_ADDRESS = this.accounts.scanner.address;
-
+                expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(true);
                 await expect(this.nodeRunners.connect(this.accounts.manager).disableScanner(SCANNER_ADDRESS))
                     .to.emit(this.nodeRunners, 'ScannerEnabled')
                     .withArgs(SCANNER_ADDRESS, false, this.accounts.manager.address, true);
-
+                expect(await this.nodeRunners.getScanner(SCANNER_ADDRESS).then((scanner) => scanner.disabled)).to.be.equal(true);
+                expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(false);
                 await expect(this.nodeRunners.connect(this.accounts.manager).enableScanner(SCANNER_ADDRESS))
                     .to.emit(this.nodeRunners, 'ScannerEnabled')
                     .withArgs(SCANNER_ADDRESS, true, this.accounts.manager.address, false);
-
+                expect(await this.nodeRunners.getScanner(SCANNER_ADDRESS).then((scanner) => scanner.disabled)).to.be.equal(false);
                 expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(true);
+            });
+            it('should fail to enable if new scanners shutdowns pool', async function () {
+                await this.staking.connect(this.accounts.user1).deposit(2, 1, '100');
+                await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(scanner2Registration, scanner2Signature);
+                await this.nodeRunners.connect(this.accounts.user1).disableScanner(SCANNER_ADDRESS_2);
+                await this.staking.connect(this.accounts.user1).initiateWithdrawal(2, 1, '100');
+                await expect(this.nodeRunners.connect(this.accounts.manager).enableScanner(SCANNER_ADDRESS_2)).to.be.revertedWith('ActionShutsDownPool()');
             });
 
             it('restricted', async function () {
                 const SCANNER_ADDRESS = this.accounts.scanner.address;
-
                 await expect(this.nodeRunners.connect(this.accounts.other).disableScanner(SCANNER_ADDRESS)).to.be.reverted;
             });
         });
@@ -382,31 +417,6 @@ describe('Node Runner Registry', function () {
                 const SCANNER_ADDRESS = this.accounts.scanner.address;
 
                 await expect(this.nodeRunners.connect(this.accounts.other).disableScanner(SCANNER_ADDRESS)).to.be.reverted;
-            });
-        });
-
-        describe('stake', async function () {
-            it.skip('re-enable', async function () {
-                const SCANNER_ADDRESS = this.accounts.scanner.address;
-
-                await expect(this.nodeRunners.connect(this.accounts.scanner).disableScanner(SCANNER_ADDRESS))
-                    .to.emit(this.nodeRunners, 'ScannerEnabled')
-                    .withArgs(SCANNER_ADDRESS, false, 1, true);
-
-                await expect(this.nodeRunners.connect(this.accounts.scanner).enableScanner(SCANNER_ADDRESS))
-                    .to.emit(this.nodeRunners, 'ScannerEnabled')
-                    .withArgs(SCANNER_ADDRESS, true, 1, false);
-
-                expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(true);
-            });
-            it.skip('isScannerOperational reacts to stake changes', async function () {
-                const SCANNER_ADDRESS = this.accounts.scanner.address;
-                const SCANNER_SUBJECT_ID = ethers.BigNumber.from(SCANNER_ADDRESS);
-                expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(true);
-                await this.nodeRunners.connect(this.accounts.manager).setStakeThreshold({ max: '100000', min: '10000', activated: true }, 1);
-                expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(false);
-                await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.SCANNER, SCANNER_SUBJECT_ID, '10000');
-                expect(await this.nodeRunners.isScannerOperational(SCANNER_ADDRESS)).to.be.equal(true);
             });
         });
     });

--- a/test/components/staking.delegation.js
+++ b/test/components/staking.delegation.js
@@ -26,7 +26,8 @@ const MIN_STAKE_MANAGED = '100';
 const STAKE = '10000';
 const chainId = 1;
 let SCANNERS;
-describe('Staking - Delegation', function () {
+let initiallyAllocated;
+describe.only('Staking - Delegation', function () {
     prepare({
         stake: {
             scanners: { min: MIN_STAKE_MANAGED, max: MAX_STAKE_MANAGED, activated: true },
@@ -46,7 +47,8 @@ describe('Staking - Delegation', function () {
         await this.nodeRunners.connect(this.accounts.user1).registerNodeRunner(chainId);
         expect(await this.nodeRunners.ownerOf('1')).to.eq(this.accounts.user1.address);
         const network = await ethers.provider.getNetwork();
-
+        initiallyAllocated = MIN_STAKE_MANAGED * SCANNERS.length;
+        await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, initiallyAllocated);
         const verifyingContractInfo = {
             address: this.nodeRunners.address,
             chainId: network.chainId,
@@ -61,7 +63,7 @@ describe('Staking - Delegation', function () {
             };
             const signature = await signERC712ScannerRegistration(verifyingContractInfo, registration, scanner);
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
-            expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
+            expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(true);
         }
     });
 
@@ -80,49 +82,29 @@ describe('Staking - Delegation', function () {
             it('should allocate between all managed subjects', async function () {
                 await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, '100'))
                     .to.emit(this.stakeAllocator, 'AllocatedStake')
-                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '100', '100');
+                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '100', 100 + initiallyAllocated);
 
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('100');
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('100');
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(100 + initiallyAllocated);
+                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(100 + initiallyAllocated);
                 expect(await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('0');
 
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('33');
-                expect(33).to.be.lt((await this.nodeRunners.getManagedStakeThreshold(1)).min);
-                for (const scanner of SCANNERS) {
-                    expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
-                }
-                await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, '200'))
-                    .to.emit(this.stakeAllocator, 'AllocatedStake')
-                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '200', '300');
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('300');
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('300');
-                expect(await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('0');
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('100');
+                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('133');
+                expect(133).to.be.gt((await this.nodeRunners.getManagedStakeThreshold(1)).min);
                 for (const scanner of SCANNERS) {
                     expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(true);
                 }
-
-                await expect(this.staking.connect(this.accounts.user1).deposit(delegatorSubjectType, nodeRunnerId, '100'))
-                    .to.emit(this.stakeAllocator, 'AllocatedStake')
-                    .withArgs(delegatorSubjectType, nodeRunnerId, true, '100', '100');
-                expect(await this.staking.activeStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('100');
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('300');
-                expect(await this.stakeAllocator.allocatedStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('100');
-                expect(await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('0');
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('133');
-                expect(await this.stakeAllocator.allocatedOwnStakePerManaged(2, 1)).to.eq('100');
-                expect(await this.stakeAllocator.allocatedDelegatorsStakePerManaged(2, 1)).to.eq('33');
             });
 
             it('delegating over max goes to unallocated', async function () {
-                const staked = MAX_STAKE_MANAGED * 3;
+                const maxAllocated = MAX_STAKE_MANAGED * 3;
+                const staked = maxAllocated - initiallyAllocated;
                 await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked))
                     .to.emit(this.stakeAllocator, 'AllocatedStake')
-                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, staked, staked);
+                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, staked, maxAllocated);
 
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(staked);
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(maxAllocated);
                 expect(await this.staking.activeStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('0');
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(staked);
+                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(maxAllocated);
                 expect(await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('0');
                 expect(await this.stakeAllocator.allocatedStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('0');
                 expect(await this.stakeAllocator.unallocatedStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('0');
@@ -133,9 +115,9 @@ describe('Staking - Delegation', function () {
                 await expect(this.staking.connect(this.accounts.user1).deposit(delegatorSubjectType, nodeRunnerId, '200'))
                     .to.emit(this.stakeAllocator, 'UnallocatedStake')
                     .withArgs(delegatorSubjectType, nodeRunnerId, true, '200', '200');
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(staked);
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(maxAllocated);
                 expect(await this.staking.activeStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('200');
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(staked);
+                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(maxAllocated);
                 expect(await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('0');
                 expect(await this.stakeAllocator.allocatedStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('0');
                 expect(await this.stakeAllocator.unallocatedStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('200');
@@ -147,16 +129,15 @@ describe('Staking - Delegation', function () {
             it('allocation should be sensitive to managed subject disabling', async function () {
                 await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, '200'))
                     .to.emit(this.stakeAllocator, 'AllocatedStake')
-                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '200', '200');
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('200');
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('200');
+                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '200', initiallyAllocated + 200);
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(initiallyAllocated + 200);
+                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(initiallyAllocated + 200);
                 expect(await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('0');
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('66');
+                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('166');
                 for (const scanner of SCANNERS) {
                     expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
                 }
                 await this.nodeRunners.connect(this.accounts.user1).disableScanner(SCANNERS[0].address);
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('100');
                 for (const scanner of SCANNERS) {
                     if (scanner === SCANNERS[0]) {
                         expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
@@ -164,26 +145,27 @@ describe('Staking - Delegation', function () {
                         expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(true);
                     }
                 }
+                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('250');
                 await this.nodeRunners.connect(this.accounts.user1).enableScanner(SCANNERS[0].address);
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('66');
+                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('166');
                 for (const scanner of SCANNERS) {
-                    expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
+                    expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(true);
                 }
             });
 
-            it('allocation should be sensitive to managed subject disabling - with delegation', async function () {
+            it.only('allocation should be sensitive to managed subject disabling - with delegation', async function () {
                 await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, '200'))
                     .to.emit(this.stakeAllocator, 'AllocatedStake')
-                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '200', '200');
+                    .withArgs(nodeRunnerSubjectType, nodeRunnerId, true, '200', initiallyAllocated + 200);
                 expect(await this.subjectGateway.minManagedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('100');
                 expect(await this.subjectGateway.totalManagedSubjects(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3');
 
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('66');
+                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('166');
                 for (const scanner of SCANNERS) {
-                    expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
+                    expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(true);
                 }
                 await this.nodeRunners.connect(this.accounts.user1).disableScanner(SCANNERS[0].address);
-                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('100');
+                expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('250');
                 for (const scanner of SCANNERS) {
                     if (scanner === SCANNERS[0]) {
                         expect(await this.nodeRunners.isScannerOperational(scanner.address)).to.eq(false);
@@ -194,12 +176,12 @@ describe('Staking - Delegation', function () {
                 await expect(this.staking.connect(this.accounts.user1).deposit(delegatorSubjectType, nodeRunnerId, '100'))
                     .to.emit(this.stakeAllocator, 'AllocatedStake')
                     .withArgs(delegatorSubjectType, nodeRunnerId, true, '100', '100');
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('200');
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(initiallyAllocated + 200);
                 expect(await this.staking.activeStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('100');
 
-                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('200');
+                expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq(initiallyAllocated + 200);
                 expect(await this.stakeAllocator.allocatedStakeFor(delegatorSubjectType, nodeRunnerId)).to.eq('100');
-                expect(await this.stakeAllocator.allocatedManagedStake(nodeRunnerSubjectType, nodeRunnerId)).to.eq('300');
+                expect(await this.stakeAllocator.allocatedManagedStake(nodeRunnerSubjectType, nodeRunnerId)).to.eq(initiallyAllocated + 300);
 
                 await this.nodeRunners.connect(this.accounts.user1).enableScanner(SCANNERS[0].address);
                 expect(await this.stakeAllocator.allocatedStakePerManaged(2, 1)).to.eq('100');
@@ -208,8 +190,8 @@ describe('Staking - Delegation', function () {
                 }
             });
 
-            it('active stake = allocated + unallocated', async function () {
-                const staked = Number(STAKE);
+            it.only('active stake = allocated + unallocated', async function () {
+                const staked = Number(STAKE) - initiallyAllocated;
 
                 await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked))
                     .to.emit(this.staking, 'StakeDeposited')
@@ -222,7 +204,7 @@ describe('Staking - Delegation', function () {
                 expect(active).to.eq(staked);
                 const maxAllocated = Number(MAX_STAKE_MANAGED) * SCANNERS.length;
                 const allocated = await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId);
-                expect(allocated).to.eq(`${maxAllocated}`);
+                expect(allocated).to.eq(`${Number(STAKE)}`);
                 const unallocated = await this.stakeAllocator.unallocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId);
                 const expectedUnallocated = staked - maxAllocated;
                 expect(unallocated).to.eq(`${expectedUnallocated}`);
@@ -246,8 +228,9 @@ describe('Staking - Delegation', function () {
                 }
             });
 
-            it('should not allow delegation if DELEGATE delegation under min', async function () {
+            it.only('should not allow delegation if DELEGATE delegation under min', async function () {
                 const staked = '2000';
+                await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(nodeRunnerSubjectType, nodeRunnerId, 200);
                 await expect(this.staking.connect(this.accounts.user2).deposit(delegatorSubjectType, nodeRunnerId, staked)).to.be.revertedWith('CannotDelegateStakeUnderMin(2, 1)');
             });
 
@@ -261,7 +244,7 @@ describe('Staking - Delegation', function () {
 
         describe('Unallocation and Manual Allocation', function () {
             it('should unallocate allocated stake', async function () {
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
                 expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
@@ -286,12 +269,12 @@ describe('Staking - Delegation', function () {
                 }
             });
 
-            it('should revert if unallocating more than allocated', async function () {
-                const staked = '3000';
+            it.only('should revert if unallocating more than allocated', async function () {
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 const unallocated = '4000';
                 await expect(this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(nodeRunnerSubjectType, nodeRunnerId, unallocated)).to.be.revertedWith(
-                    `AmountTooLarge(${unallocated}, ${staked})`
+                    `AmountTooLarge(${unallocated}, ${3000})`
                 );
 
                 await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(nodeRunnerSubjectType, nodeRunnerId, '1000');
@@ -302,7 +285,7 @@ describe('Staking - Delegation', function () {
 
             it('should disable managed subjects if unallocate under min managed', async function () {
                 await this.nodeRunners.connect(this.accounts.manager).setManagedStakeThreshold({ max: '10000', min: '1000', activated: true }, 1);
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
                 expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
@@ -326,7 +309,7 @@ describe('Staking - Delegation', function () {
                 }
             });
             it('should allocate after unallocate', async function () {
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
                 expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
@@ -366,7 +349,7 @@ describe('Staking - Delegation', function () {
 
         describe('On Init Withdraw', function () {
             it('burns from allocated', async function () {
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
                 expect(await this.stakeAllocator.allocatedStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
@@ -382,7 +365,7 @@ describe('Staking - Delegation', function () {
             });
 
             it('burns from unallocated and allocated', async function () {
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(nodeRunnerSubjectType, nodeRunnerId, '2000');
                 expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
@@ -399,7 +382,7 @@ describe('Staking - Delegation', function () {
             });
 
             it('burns from unallocated', async function () {
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(nodeRunnerSubjectType, nodeRunnerId, '3000');
                 expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.eq('3000');
@@ -416,7 +399,7 @@ describe('Staking - Delegation', function () {
 
         describe('On Slashing', function () {
             it('burns from unallocated and allocated', async function () {
-                const staked = '3000';
+                const staked = 3000 - initiallyAllocated;
                 await this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, staked);
                 await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(nodeRunnerSubjectType, nodeRunnerId, '2000');
                 await this.nodeRunners.connect(this.accounts.manager).setManagedStakeThreshold({ max: '100000', min: '333', activated: true }, 1);
@@ -445,11 +428,11 @@ describe('Staking - Delegation', function () {
                 await expect(this.staking.setDelay(DELAY)).to.emit(this.staking, 'DelaySet').withArgs(DELAY);
             });
 
-            it('happy path', async function () {
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('0');
-                expect(await this.staking.totalActiveStake()).to.be.equal('0');
-                expect(await this.staking.sharesOf(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address)).to.be.equal('0');
-                expect(await this.staking.totalShares(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('0');
+            it.only('happy path', async function () {
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal(initiallyAllocated);
+                expect(await this.staking.totalActiveStake()).to.be.equal(initiallyAllocated);
+                expect(await this.staking.sharesOf(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address)).to.be.equal(initiallyAllocated);
+                expect(await this.staking.totalShares(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal(initiallyAllocated);
 
                 await expect(this.staking.connect(this.accounts.user1).deposit(nodeRunnerSubjectType, nodeRunnerId, '100'))
                     .to.emit(this.token, 'Transfer')
@@ -459,10 +442,10 @@ describe('Staking - Delegation', function () {
                     .to.emit(this.staking, 'StakeDeposited')
                     .withArgs(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address, '100');
 
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('100');
-                expect(await this.staking.totalActiveStake()).to.be.equal('100');
-                expect(await this.staking.sharesOf(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address)).to.be.equal('100');
-                expect(await this.staking.totalShares(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('100');
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('100' + initiallyAllocated);
+                expect(await this.staking.totalActiveStake()).to.be.equal('100' + initiallyAllocated);
+                expect(await this.staking.sharesOf(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address)).to.be.equal('100' + initiallyAllocated);
+                expect(await this.staking.totalShares(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('100' + initiallyAllocated);
 
                 await expect(this.staking.connect(this.accounts.user1).withdraw(nodeRunnerSubjectType, nodeRunnerId)).to.be.reverted;
 
@@ -484,13 +467,11 @@ describe('Staking - Delegation', function () {
                     .to.emit(this.staking, 'WithdrawalExecuted')
                     .withArgs(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address);
 
-                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('50');
-                expect(await this.staking.totalActiveStake()).to.be.equal('50');
-                expect(await this.staking.sharesOf(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address)).to.be.equal('50');
-                expect(await this.staking.totalShares(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('50');
+                expect(await this.staking.activeStakeFor(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('50' + initiallyAllocated);
+                expect(await this.staking.totalActiveStake()).to.be.equal('50' + initiallyAllocated);
+                expect(await this.staking.sharesOf(nodeRunnerSubjectType, nodeRunnerId, this.accounts.user1.address)).to.be.equal('50' + initiallyAllocated);
+                expect(await this.staking.totalShares(nodeRunnerSubjectType, nodeRunnerId)).to.be.equal('50' + initiallyAllocated);
             });
         });
-
-        describe('Delegator', function () {});
     });
 });

--- a/test/components/staking.rewards.test.js
+++ b/test/components/staking.rewards.test.js
@@ -75,8 +75,8 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '50');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '50');
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -123,8 +123,8 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -158,8 +158,8 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -196,8 +196,8 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -233,13 +233,14 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
-            await this.stakeAllocator.connect(this.accounts.user1).unallocateDelegatorStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
+            await this.stakeAllocator.connect(this.accounts.user1).unallocateDelegatorStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
 
+            expect(await this.stakeAllocator.allocatedStakeFor(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID)).to.be.equal('100');
+            expect(await this.stakeAllocator.allocatedStakeFor(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID)).to.be.equal('0');
             expect(await this.stakeAllocator.allocatedManagedStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID)).to.be.equal('100');
 
             const latestTimestamp = await helpers.time.latest();
@@ -272,12 +273,12 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
-            await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '50');
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
 
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
+            await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '50');
 
             expect(await this.stakeAllocator.allocatedManagedStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID)).to.be.equal('150');
 
@@ -311,8 +312,8 @@ describe('Staking Rewards', function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -356,12 +357,20 @@ describe('Staking Rewards', function () {
             await helpers.time.increase(2 * (1 + EPOCH_LENGTH) /* 2 week */);
             currentEpoch = await this.rewardsDistributor.getCurrentEpochNumber();
             console.log(await this.rewardsDistributor.getDelegationFee(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, currentEpoch));
-
+            const registration = {
+                scanner: this.SCANNER_ID,
+                nodeRunnerId: 1,
+                chainId: 1,
+                metadata: 'metadata',
+                timestamp: (await ethers.provider.getBlock('latest')).timestamp,
+            };
+            const signature = await signERC712ScannerRegistration(verifyingContractInfo, registration, this.accounts.scanner);
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
-            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
+            await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 

--- a/test/components/staking.rewards.test.js
+++ b/test/components/staking.rewards.test.js
@@ -22,6 +22,7 @@ const [[subject1, subjectType1, active1, inactive1], [NODE_RUNNER_ID, NODE_RUNNE
 
 const MAX_STAKE = '10000';
 const OFFSET = 4 * 24 * 60 * 60;
+let registration, signature, verifyingContractInfo;
 describe('Staking Rewards', function () {
     prepare({
         stake: {
@@ -49,20 +50,19 @@ describe('Staking Rewards', function () {
         this.accounts.getAccount('scanner');
         this.SCANNER_ID = this.accounts.scanner.address;
         const { chainId } = await ethers.provider.getNetwork();
-        const verifyingContractInfo = {
+        verifyingContractInfo = {
             address: this.contracts.nodeRunners.address,
             chainId: chainId,
         };
-        const registration = {
+        registration = {
             scanner: this.SCANNER_ID,
             nodeRunnerId: 1,
             chainId: 1,
             metadata: 'metadata',
             timestamp: (await ethers.provider.getBlock('latest')).timestamp,
         };
-        const signature = await signERC712ScannerRegistration(verifyingContractInfo, registration, this.accounts.scanner);
+        signature = await signERC712ScannerRegistration(verifyingContractInfo, registration, this.accounts.scanner);
 
-        await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
     });
 
     describe('Rewards tracking stake allocation', function () {
@@ -76,6 +76,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '50');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -123,6 +124,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -157,6 +159,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -194,6 +197,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -230,6 +234,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await this.stakeAllocator.connect(this.accounts.user1).unallocateDelegatorStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
 
             await network.provider.send('evm_setAutomine', [true]);
@@ -268,6 +273,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await this.stakeAllocator.connect(this.accounts.user1).unallocateOwnStake(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '50');
 
             await network.provider.send('evm_setAutomine', [true]);
@@ -306,6 +312,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 
@@ -354,6 +361,7 @@ describe('Staking Rewards', function () {
             await network.provider.send('evm_setAutomine', [false]);
             await this.staking.connect(this.accounts.user1).deposit(NODE_RUNNER_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
             await this.staking.connect(this.accounts.user2).deposit(DELEGATOR_SUBJECT_TYPE, NODE_RUNNER_ID, '100');
+            await this.nodeRunners.connect(this.accounts.user1).registerScannerNode(registration, signature);
             await network.provider.send('evm_setAutomine', [true]);
             await network.provider.send('evm_mine');
 


### PR DESCRIPTION
To improve the stability of the system, changes are introduced in NodeRunnerRegistry so that registering a new scanner node or enabling a disabled one will fail if the resulting `allocatedStake / scanners < min for scanner`.

- Method `allocationOnAddedEnabledScanner(uint256 nodeRunnerId)` is introduced, and called in `registerScannerNode` and `enableScanner()`. It allocates allunallocated stake if a there is a new scanner enabled on the pool and not enough allocated stake. If there is not enough unallocated stake, the method will revert.

This changes the assumption that you could register scanners before staking, so now the flow is:
1. Register NodeRunnerRegistry
2. Deposit stake on the node runner id (this stake will go to unallocated)
3. Register scanners, while (allocated + unallocated) / scanners >= min

- Helper method `function willNewScannerShutdownPool(uint256 nodeRunnerId) public view returns (bool)` tells integrations before a failing transaction, so they could warn the user that she needs to stake more.