### PR TITLE
Fixes reward distribution accounting

### DIFF
--- a/test/components/staking.rewards.test.js
+++ b/test/components/staking.rewards.test.js
@@ -70,6 +70,15 @@ describe('Staking Rewards', function () {
             await this.rewardsDistributor.connect(this.accounts.admin).setDelegationParams(delay, 0);
         });
 
+        it('should not allow rewarding twice', async function () {
+            const epoch = await this.rewardsDistributor.getCurrentEpochNumber();
+            await helpers.time.increase(1 + EPOCH_LENGTH /* 1 week */);
+            await this.rewardsDistributor.connect(this.accounts.manager).reward(SCANNER_POOL_SUBJECT_TYPE, SCANNER_POOL_ID, '2000', epoch);
+            await expect(this.rewardsDistributor.connect(this.accounts.manager).reward(SCANNER_POOL_SUBJECT_TYPE, SCANNER_POOL_ID, '2000', epoch)).to.be.revertedWith(
+                `AlreadyRewarded(${epoch})`
+            );
+        });
+
         it('should apply equal rewards with comission for stakes added at the same time', async function () {
             // disable automine so deposits are instantaneous to simplify math
             await network.provider.send('evm_setAutomine', [false]);


### PR DESCRIPTION
- Checks if pool already rewarded in that epoch to avoid "double rewarding"
- Substitutes `totalRewardsDistributed` by `unclaimedRewards` (substracted from on claims) so `sweep()` accounting makes sense.
- Makes public reward claims related properties for easier external access.