### PR TITLE
Add zero stake check chen reviewing slash proposal

### DIFF
--- a/contracts/components/staking/slashing/SlashingController.sol
+++ b/contracts/components/staking/slashing/SlashingController.sol
@@ -221,7 +221,7 @@ contract SlashingController is BaseComponentUpgradeable, StateMachineController,
     ) external onlyRole(SLASHING_ARBITER_ROLE) onlyInState(_proposalId, IN_REVIEW) onlyValidSlashPenaltyId(_penaltyId) onlyValidSubjectType(_subjectType) notAgencyType(_subjectType, SubjectStakeAgency.DELEGATOR) {
         // No need to check for proposal existence, onlyInState will revert if _proposalId is in undefined state
         if (!subjectGateway.isRegistered(_subjectType, _subjectId)) revert NonRegisteredSubject(_subjectType, _subjectId);
-
+        if (subjectGateway.totalStakeFor(_subjectType, _subjectId) == 0) revert ZeroAmount("subject stake");
         _submitEvidence(_proposalId, IN_REVIEW, _evidence);
         if (_subjectType != proposals[_proposalId].subjectType || _subjectId != proposals[_proposalId].subjectId) {
             _unfreeze(_proposalId);


### PR DESCRIPTION
Since arbiters can point to different subject types, this will reduce operational errors.