### PR TITLE
Mitigate agent creation DOS

### DIFF
--- a/test/components/agents.test.js
+++ b/test/components/agents.test.js
@@ -15,7 +15,7 @@ describe('Agent Registry', function () {
             await expect(this.agents.connect(this.accounts.manager).setFrontRunningDelay('1800'))
                 .to.emit(this.agents, 'FrontRunningDelaySet')
                 .withArgs(ethers.BigNumber.from('1800'));
-            await expect(this.agents.createAgent(...args)).to.be.revertedWith('CommitNotReady()');
+            await expect(this.agents.connect(this.accounts.user1).createAgent(...args)).to.be.revertedWith('CommitNotReady()');
         });
 
         it('setting delay is protected', async function () {
@@ -33,7 +33,7 @@ describe('Agent Registry', function () {
 
                 await this.agents.prepareAgent(prepareCommit(...args));
 
-                await expect(this.agents.createAgent(...args)).to.be.revertedWith('CommitNotReady()');
+                await expect(this.agents.connect(this.accounts.user1).createAgent(...args)).to.be.revertedWith('CommitNotReady()');
             });
 
             it('non existing agent', async function () {
@@ -47,11 +47,11 @@ describe('Agent Registry', function () {
             it('no delay', async function () {
                 const args = [AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4, 5]];
 
-                await expect(this.agents.connect(this.accounts.other).createAgent(...args))
+                await expect(this.agents.connect(this.accounts.user1).createAgent(...args))
                     .to.emit(this.agents, 'Transfer')
                     .withArgs(ethers.constants.AddressZero, this.accounts.user1.address, AGENT_ID)
                     .to.emit(this.agents, 'AgentUpdated')
-                    .withArgs(AGENT_ID, this.accounts.other.address, 'Metadata1', [1, 3, 4, 5]);
+                    .withArgs(AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4, 5]);
             });
 
             it('on time', async function () {
@@ -73,11 +73,11 @@ describe('Agent Registry', function () {
 
                 await network.provider.send('evm_increaseTime', [300]);
 
-                await expect(this.agents.connect(this.accounts.other).createAgent(...args))
+                await expect(this.agents.connect(this.accounts.user1).createAgent(...args))
                     .to.emit(this.agents, 'Transfer')
                     .withArgs(ethers.constants.AddressZero, this.accounts.user1.address, AGENT_ID)
                     .to.emit(this.agents, 'AgentUpdated')
-                    .withArgs(AGENT_ID, this.accounts.other.address, 'Metadata1', [1, 3, 4, 5]);
+                    .withArgs(AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4, 5]);
                 expect(await this.agents.isRegistered(AGENT_ID)).to.be.equal(true);
                 expect(await this.agents.ownerOf(AGENT_ID)).to.be.equal(this.accounts.user1.address);
                 expect(
@@ -107,7 +107,7 @@ describe('Agent Registry', function () {
 
                 await network.provider.send('evm_increaseTime', [300]);
 
-                await expect(this.agents.createAgent(...args)).to.be.revertedWith('UnorderedArray("chainIds")');
+                await expect(this.agents.connect(this.accounts.user1).createAgent(...args)).to.be.revertedWith('UnorderedArray("chainIds")');
             });
 
             it('update', async function () {
@@ -126,11 +126,11 @@ describe('Agent Registry', function () {
 
                 await network.provider.send('evm_increaseTime', [300]);
 
-                await expect(this.agents.connect(this.accounts.other).createAgent(...args))
+                await expect(this.agents.connect(this.accounts.user1).createAgent(...args))
                     .to.emit(this.agents, 'Transfer')
                     .withArgs(ethers.constants.AddressZero, this.accounts.user1.address, AGENT_ID)
                     .to.emit(this.agents, 'AgentUpdated')
-                    .withArgs(AGENT_ID, this.accounts.other.address, 'Metadata1', [1, 3, 4]);
+                    .withArgs(AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4]);
 
                 expect(await this.agents.ownerOf(AGENT_ID)).to.be.equal(this.accounts.user1.address);
                 expect(
@@ -188,7 +188,7 @@ describe('Agent Registry', function () {
             const args = [AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4, 5]];
             await expect(this.agents.prepareAgent(prepareCommit(...args))).to.be.not.reverted;
             await network.provider.send('evm_increaseTime', [300]);
-            await expect(this.agents.createAgent(...args)).to.be.not.reverted;
+            await expect(this.agents.connect(this.accounts.user1).createAgent(...args)).to.be.not.reverted;
             await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.AGENT, AGENT_ID, '100');
         });
 

--- a/test/components/dispatcher.test.js
+++ b/test/components/dispatcher.test.js
@@ -19,7 +19,7 @@ describe('Dispatcher', function () {
         this.AGENT_ID = ethers.utils.hexlify(ethers.utils.randomBytes(32));
         this.SCANNER_SUBJECT_ID = BigNumber.from(this.SCANNER_ID);
         // Create Agent and Scanner
-        await this.agents.createAgent(this.AGENT_ID, this.accounts.user1.address, 'Metadata1', [1, 3, 4, 5]);
+        await this.agents.connect(this.accounts.user1).registerAgent(this.AGENT_ID, 'Metadata1', [1, 3, 4, 5]);
         await this.staking.connect(this.accounts.staker).deposit(this.stakingSubjects.AGENT, this.AGENT_ID, '100');
 
         await this.scannerPools.connect(this.accounts.user1).registerScannerPool(1);
@@ -157,7 +157,7 @@ describe('Dispatcher', function () {
         for (const i in Array(10).fill()) {
             for (const j in Array(10).fill()) {
                 const agent = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-                await expect(this.agents.createAgent(agent, this.accounts.user1.address, `Agent ${i * 10 + j}`, [1])).to.be.not.reverted;
+                await expect(this.agents.connect(this.accounts.user1).registerAgent(agent, `Agent ${i * 10 + j}`, [1])).to.be.not.reverted;
                 await expect(this.dispatch.connect(this.accounts.manager).link(agent, this.SCANNER_ID)).to.be.not.reverted;
             }
 


### PR DESCRIPTION
Create agent only mints tokens to sender, added comment explaining how `agentIds` are generated.