### PR TITLE
WIP: [Forta 645] Add unclaimed rewarded events for apr calculation

### DIFF
--- a/subgraph/src/datasources/FortaStaking.ts
+++ b/subgraph/src/datasources/FortaStaking.ts
@@ -27,6 +27,7 @@ import { fetchAccount } from "../fetch/account";
 
 import { events, transactions } from "@amxx/graphprotocol-utils/";
 import { fetchScannerPool } from "../fetch/scannerpool";
+import { formatSubjectId } from "./utils";
 
 function hexToDec(s: string): string {
   var i: i32, j: i32, digits: i32[] = [0], carry: i32;
@@ -71,10 +72,6 @@ function getActiveSharesId(_subjectType: i32, _subject: BigInt): string {
 
 export function getStakeId(subjectId: string, stakerId: string, subjectType: string): string {
   return subjectType + subjectId + stakerId;
-}
-
-function formatSubjectId(subjectId: BigInt, subjectType: i32): string {
-  return subjectType === 2 ? subjectId.toBigDecimal().toString() : subjectId.toHexString();
 }
 
 function updateAggregateStake(stakerId: string, prevStakeTotalShares: BigInt , prevStateInActiveShares: BigInt , updatedStakeTotalShares: BigInt, updatedStakeInActiveShares: BigInt): void {

--- a/subgraph/src/datasources/utils.ts
+++ b/subgraph/src/datasources/utils.ts
@@ -1,0 +1,6 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
+
+export function formatSubjectId(subjectId: BigInt, subjectType: i32): string {
+    return subjectType === 2 ? subjectId.toBigDecimal().toString() : subjectId.toHexString();
+}

--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -166,6 +166,7 @@ type Subject @entity {
   stakes: [Stake!]! @derivedFrom(field: "subject")
   stakeDepositedEvents: [StakeDepositEvent!] @derivedFrom(field: "subject")
   withdrawalExecutedEvents: [WithdrawalExecutedEvent!] @derivedFrom(field: "subject")
+  rewardedEvents: [RewardEvent!] @derivedFrom(field: "subject")
 }
 
 type SharesID @entity {
@@ -193,7 +194,6 @@ type Staker @entity {
   id: ID!
   account: Account!
   stakes: [Stake!]! @derivedFrom(field: "staker")
-  releasedRewards: [Reward!] @derivedFrom(field: "staker")
   aggregateActiveStake: AggregateActiveStake! @derivedFrom(field: "staker")
   aggregateTotalStake: AggregateTotalStake! @derivedFrom(field: "staker")
   nodePools: [ScannerPool!]
@@ -238,6 +238,13 @@ type WithdrawalExecutedEvent implements Event @entity {
   subject: Subject!
   stake: Stake!
   amount: BigInt
+}
+
+type RewardEvent implements Event @entity {
+  id: ID!
+  subject: Subject!
+  epochNumber: Int!
+  amount: BigInt!
 }
 
 type ScannerPool @entity {

--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -262,6 +262,7 @@ type ScannerPool @entity {
   stakeAllocated: BigInt!
   stakeOwnedAllocated: BigInt!
   scanNodes: [ScanNode!] @derivedFrom(field: "scannerPool")
+  stakers: [Staker!]
 }
 
 #  New entity to handle scanNodes inside of pools

--- a/subgraph/src/tests/helpers/RewardsDistributorHelper.ts
+++ b/subgraph/src/tests/helpers/RewardsDistributorHelper.ts
@@ -1,0 +1,41 @@
+import { Address, BigInt, ethereum, crypto, ByteArray, log } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+import {Rewarded as RewardedEvent } from "../../../generated/RewardsDistributor/RewardsDistributor";
+
+
+export function createRewardEvent(
+    subjectType: i32,
+    subject: BigInt,
+    from: Address,
+    value: BigInt
+  ): RewardedEvent {
+    const mockRewardedEvent = changetype<RewardedEvent>(newMockEvent());
+    mockRewardedEvent.parameters = [];
+  
+    const subjectTypeParam = new ethereum.EventParam(
+      "subjectType",
+      ethereum.Value.fromI32(subjectType)
+    );
+  
+    const subjectParam = new ethereum.EventParam(
+      "subject",
+      ethereum.Value.fromUnsignedBigInt(subject)
+    );
+  
+    const fromParam = new ethereum.EventParam(
+      "from",
+      ethereum.Value.fromAddress(from)
+    );
+  
+    const valueParam = new ethereum.EventParam(
+      "value",
+      ethereum.Value.fromSignedBigInt(value)
+    );
+  
+    mockRewardedEvent.parameters.push(subjectTypeParam);
+    mockRewardedEvent.parameters.push(subjectParam);
+    mockRewardedEvent.parameters.push(fromParam);
+    mockRewardedEvent.parameters.push(valueParam);
+  
+    return mockRewardedEvent;
+  }

--- a/subgraph/src/tests/rewardsDistributor.test.ts
+++ b/subgraph/src/tests/rewardsDistributor.test.ts
@@ -1,0 +1,28 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { describe, test } from "matchstick-as";
+
+
+// Address of rewards distributor
+let contractAddress = Address.fromString(
+    "0xd2863157539b1D11F39ce23fC4834B62082F6874"
+  );
+
+describe('Rewards distributor', () => {
+    test('should handle a reward event for a node owner and add it to correct scannerPool entity', () => {
+        // Given
+            // Mock a nodePool and reward event
+        // When
+            // A reward event with subject type 2 (owner)
+        // Expect
+            // The correct reward event added to scannerPool entity
+    }) 
+
+    test('should handle a reward event for a delegator and add it to correct scannerPool entity', () => {
+         // Given
+            // Mock a nodePool and reward event
+        // When
+            // A reward event with subject type 3 (delegator)
+        // Expect
+            // The correct reward event added to scannerPool entity
+    }) 
+})


### PR DESCRIPTION
- [ ] Updated the `ScannerPool` entity to have a list of all stakers (both owners and delegators)
- [ ] Added handler `Reward` events (unclaimed rewards given) to the corresponding `Subject` entity


We can get all the total unclaimed rewards on a given nodePool on a given epoch in a single query with these changes.


