### PR TITLE
[Forta 692] allow sort for apy

### DIFF
--- a/subgraph/src/datasources/RewardsDistributor.ts
+++ b/subgraph/src/datasources/RewardsDistributor.ts
@@ -99,11 +99,11 @@ export function handleRewardEvent(event: RewardedDistributedEvent): void {
     rewardedEvent.epochNumber = epochNumber.toI32();
     rewardedEvent.transaction = transactions.log(event).id;
     rewardedEvent.timestamp = event.block.timestamp;
-    rewardedEvent.apyForLastEpoch = apy;
+    rewardedEvent.apyForLastEpoch = apy ? apy : BigDecimal.fromString("0");
 
     rewardedEvent.save();
 
-    nodePool.apyForLastEpoch = apy;
+    nodePool.apyForLastEpoch = apy ? apy : BigDecimal.fromString("0");
     
     const pastRewardEvents: string[]  = nodePool.rewardedEvents ? nodePool.rewardedEvents as string[] : []
 

--- a/subgraph/src/fetch/scannerpool.ts
+++ b/subgraph/src/fetch/scannerpool.ts
@@ -18,6 +18,7 @@ export function fetchScannerPool(id: BigInt): ScannerPool {
     scannerPool.stakeDelegated = BigInt.zero();
     scannerPool.stakeAllocated = BigInt.zero();
     scannerPool.stakeOwnedAllocated = BigInt.zero();
+    scannerPool.apyForLastEpoch = BigDecimal.fromString("0");
     scannerPool.owner = "";
   }
   return scannerPool as ScannerPool;

--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -255,7 +255,7 @@ type ScannerPool @entity {
   registered: Boolean!
   chainId: Int!
   apr: BigDecimal
-  apyForLastEpoch: BigDecimal
+  apyForLastEpoch: BigDecimal!
   commission: BigDecimal!
   commissionSinceEpoch: Int!
   oldCommission: BigDecimal!

--- a/subgraph/src/tests/rewardsDistributor.test.ts
+++ b/subgraph/src/tests/rewardsDistributor.test.ts
@@ -65,7 +65,7 @@ describe('Rewards distributor', () => {
     }) 
 
 
-    test('should handle a reward event on a pool with zero delegators and NOT return an APY value', () => {
+    test('should handle a reward event on a pool with zero delegators and return a 0% APY value', () => {
         const reward = BigInt.fromI32(5);
         const mockRewardedEvent = createMockRewardEvent(2, BigInt.fromString(mockNodePool.id), reward, BigInt.fromI32(2770));
         mockRewardedEvent.address = contractAddress;
@@ -76,7 +76,9 @@ describe('Rewards distributor', () => {
         const actualValue = updatedScanner ? updatedScanner.apyForLastEpoch : null
         
         if(actualValue) {
-            throw new Error("Node pool should not have an apy value")
+            assert.fieldEquals("ScannerPool", mockPoolId, "apyForLastEpoch", BigDecimal.fromString("0").toString())
+        } else {
+            throw new Error("Node pool should have a 0% apy value")
         }
     }) 
 


### PR DESCRIPTION
Right now the `apyForLastEpoch` field on `ScannerPool` entities is a nullable field. This has the effect that when trying to make sorted queries, the null values are not being correctly sorted.

This PR is to make the `apyForLastEpoch` non-nullable so we can take advantage of the graphs `orderBy` query filter correctly.