### PR TITLE
[Hotfix] Set scanner pool id to decimal

### DIFF
--- a/subgraph/src/fetch/scannerpool.ts
+++ b/subgraph/src/fetch/scannerpool.ts
@@ -4,9 +4,9 @@ import { ScannerPool } from "../../generated/schema";
 
 export function fetchScannerPool(id: BigInt): ScannerPool {
   
-  let scannerPool = ScannerPool.load(id.toHex());
+  let scannerPool = ScannerPool.load(id.toBigDecimal().toString());
   if (scannerPool == null) {
-    scannerPool = new ScannerPool(id.toHex());
+    scannerPool = new ScannerPool(id.toBigDecimal().toString());
     scannerPool.registered = false;
     scannerPool.chainId = 1;
     scannerPool.apr = BigDecimal.zero();


### PR DESCRIPTION
Reverted this change in the last merge. This caused scannerPool Id's to come in a hex instead of decimal.

- [x] Verified on dev