### PR TITLE
[Forta-618] Add amount to withdrawal events to subgraph

### DIFF
--- a/subgraph/src/datasources/FortaStaking.ts
+++ b/subgraph/src/datasources/FortaStaking.ts
@@ -285,7 +285,7 @@ export function handleWithdrawalInitiated(event: WithdrawalInitiated): void {
 
   const currentInActiveShares = currentStake.inactiveShares;
 
-  // With a withdrawl the number of inactive shares should increase
+  // With a withdrawal the number of inactive shares should increase
 
   const withdrawalInitiatedEvent = new WithdrawalInitiatedEvent(events.id(event));
   withdrawalInitiatedEvent.transaction = transactions.log(event).id;
@@ -301,14 +301,14 @@ export function handleWithdrawalInitiated(event: WithdrawalInitiated): void {
 
   withdrawalInitiatedEvent.save();
 
-  // Place pending withdrawls as a queue
-  const currentPendingQueue = currentStake.pendingWithdrawlQueue;
+  // Place pending withdrawals as a queue
+  const currentPendingQueue = currentStake.pendingWithdrawalQueue;
 
   if(currentPendingQueue) {
     currentPendingQueue.push(withdrawalInitiatedEvent.id)
-    currentStake.pendingWithdrawlQueue = currentPendingQueue;
+    currentStake.pendingWithdrawalQueue = currentPendingQueue;
   } else {
-    currentStake.pendingWithdrawlQueue = [withdrawalInitiatedEvent.id]
+    currentStake.pendingWithdrawalQueue = [withdrawalInitiatedEvent.id]
   }
 
   currentStake.save()
@@ -322,17 +322,17 @@ export function handleWithdrawalExecuted(event: WithdrawalExecuted): void {
     event.params.account,
   );
 
-  // Look up oldest pending withdrawl (with the same subject and subject type) and get amount from there
+  // Look up oldest pending withdrawal (with the same subject and subject type) and get amount from there
   const currentStake = Stake.load(stakeId) as Stake;
 
-  const pendingWithdrawlQueue = currentStake.pendingWithdrawlQueue as string[];
-  const oldestPendingWithdrawl = pendingWithdrawlQueue[0];
+  const pendingWithdrawalQueue = currentStake.pendingWithdrawalQueue as string[];
+  const oldestPendingWithdrawal = pendingWithdrawalQueue[0];
 
-  // Remove the oldest pending withdrawl
-  currentStake.pendingWithdrawlQueue = pendingWithdrawlQueue.slice(1);
+  // Remove the oldest pending withdrawal
+  currentStake.pendingWithdrawalQueue = pendingWithdrawalQueue.slice(1);
   currentStake.save();
 
-  const withdrawalInitiatedEvent = WithdrawalInitiatedEvent.load(oldestPendingWithdrawl) as WithdrawalInitiatedEvent;
+  const withdrawalInitiatedEvent = WithdrawalInitiatedEvent.load(oldestPendingWithdrawal) as WithdrawalInitiatedEvent;
 
   const withdrawalExecutedEvent = new WithdrawalExecutedEvent(events.id(event));
   withdrawalExecutedEvent.transaction = transactions.log(event).id;
@@ -396,7 +396,7 @@ export function handleTransferSingle(event: TransferSingleEvent): void {
   const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
   let sharesId = SharesID.load(event.params.id.toString());
 
-  // Update withdrawl executed event with value
+  // Update withdrawal executed event with value
 
   if(event.params.to.toHex() != ZERO_ADDRESS) {
     const account = Account.load(event.params.to.toString()) // Get account of receiver 
@@ -415,7 +415,7 @@ export function handleTransferSingle(event: TransferSingleEvent): void {
               for(let j = 0; j < events.length; j++) {
                 const withdrawalEvent = WithdrawalExecutedEvent.load(events[j]);
                 if(withdrawalEvent && withdrawalEvent.timestamp === event.block.timestamp) {
-                  log.info(`Updating withdrawl event with value`,[])
+                  log.info(`Updating withdrawal event with value`,[])
                   withdrawalEvent.amount = event.params.value
                   withdrawalEvent.save()
                 }

--- a/subgraph/src/datasources/FortaStaking.ts
+++ b/subgraph/src/datasources/FortaStaking.ts
@@ -22,6 +22,7 @@ import {
   AggregateTotalStake,
   AggregateActiveStake,
   Account,
+  WithdrawalInitiatedEvent,
 } from "../../generated/schema";
 import { fetchAccount } from "../fetch/account";
 
@@ -60,6 +61,19 @@ function getSubjectTypePrefix(subjectType: number): string {
   if(subjectType == 2) return '0x10'
   if(subjectType == 1) return '0x01'
   return '0x00'
+}
+
+function findStakeInactiveShares(_subjectType: i32, _subject: BigInt, _staker: Address): BigInt | null {
+  const _subjectId = formatSubjectId(_subject, _subjectType);
+  const _stakerId = addressToHex(_staker);
+
+  const previousStake = Stake.load(getStakeId(_subjectId,_stakerId,_subjectType.toString()));
+
+  if(!previousStake) {
+    return null
+  } 
+  
+  return previousStake.inactiveShares;
 }
 
 function getActiveSharesId(_subjectType: i32, _subject: BigInt): string {
@@ -252,12 +266,52 @@ export function handleStakeDeposited(event: StakeDepositedEvent): void {
 }
 
 export function handleWithdrawalInitiated(event: WithdrawalInitiated): void {
-  updateStake(
+
+  // Find number of inactive shares stored on stake entity before update
+  const _staker = event.params.account;
+  const _subjectType = event.params.subjectType;
+  const _subject = event.params.subject
+   
+  const previousInactiveShares = findStakeInactiveShares(_subjectType, _subject, _staker)
+
+  const stakeId = updateStake(
     event.address,
-    event.params.subjectType,
-    event.params.subject,
-    event.params.account,
+    _subjectType,
+    _subject,
+    _staker,
   );
+
+  const currentStake = Stake.load(stakeId) as Stake;
+
+  const currentInActiveShares = currentStake.inactiveShares;
+
+  // With a withdrawl the number of inactive shares should increase
+
+  const withdrawalInitiatedEvent = new WithdrawalInitiatedEvent(events.id(event));
+  withdrawalInitiatedEvent.transaction = transactions.log(event).id;
+  withdrawalInitiatedEvent.timestamp = event.block.timestamp;
+  withdrawalInitiatedEvent.stake = stakeId;
+  withdrawalInitiatedEvent.subject = formatSubjectId(event.params.subject, event.params.subjectType);
+  
+    if(previousInactiveShares) {
+      withdrawalInitiatedEvent.amount = (currentInActiveShares as BigInt).minus(previousInactiveShares)
+    } else {
+      withdrawalInitiatedEvent.amount = (currentInActiveShares as BigInt)
+    }
+
+  withdrawalInitiatedEvent.save();
+
+  // Place pending withdrawls as a queue
+  const currentPendingQueue = currentStake.pendingWithdrawlQueue;
+
+  if(currentPendingQueue) {
+    currentPendingQueue.push(withdrawalInitiatedEvent.id)
+    currentStake.pendingWithdrawlQueue = currentPendingQueue;
+  } else {
+    currentStake.pendingWithdrawlQueue = [withdrawalInitiatedEvent.id]
+  }
+
+  currentStake.save()
 }
 
 export function handleWithdrawalExecuted(event: WithdrawalExecuted): void {  
@@ -268,11 +322,24 @@ export function handleWithdrawalExecuted(event: WithdrawalExecuted): void {
     event.params.account,
   );
 
+  // Look up oldest pending withdrawl (with the same subject and subject type) and get amount from there
+  const currentStake = Stake.load(stakeId) as Stake;
+
+  const pendingWithdrawlQueue = currentStake.pendingWithdrawlQueue as string[];
+  const oldestPendingWithdrawl = pendingWithdrawlQueue[0];
+
+  // Remove the oldest pending withdrawl
+  currentStake.pendingWithdrawlQueue = pendingWithdrawlQueue.slice(1);
+  currentStake.save();
+
+  const withdrawalInitiatedEvent = WithdrawalInitiatedEvent.load(oldestPendingWithdrawl) as WithdrawalInitiatedEvent;
+
   const withdrawalExecutedEvent = new WithdrawalExecutedEvent(events.id(event));
   withdrawalExecutedEvent.transaction = transactions.log(event).id;
   withdrawalExecutedEvent.timestamp = event.block.timestamp;
   withdrawalExecutedEvent.stake = stakeId;
   withdrawalExecutedEvent.subject = formatSubjectId(event.params.subject, event.params.subjectType);
+  withdrawalExecutedEvent.amount = withdrawalInitiatedEvent.amount;
   withdrawalExecutedEvent.save();
 }
 

--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -208,6 +208,8 @@ type Stake @entity {
   inactiveShares: BigInt
   stakeDepositedEvents: [StakeDepositEvent!] @derivedFrom(field: "stake")
   withdrawalExecutedEvents: [WithdrawalExecutedEvent!] @derivedFrom(field: "stake")
+  withdrawalInitiatedEvents: [WithdrawalInitiatedEvent!] @derivedFrom(field: "stake")
+  pendingWithdrawlQueue: [WithdrawalInitiatedEvent!] @derivedFrom(field: "stake")
 }
 
 type AggregateActiveStake @entity {
@@ -229,6 +231,15 @@ type StakeDepositEvent implements Event @entity {
   subject: Subject!
   amount: BigInt!
   stake: Stake!
+}
+
+type WithdrawalInitiatedEvent implements Event @entity {
+  id: ID!
+  transaction: Transaction!
+  timestamp: BigInt!
+  subject: Subject!
+  stake: Stake!
+  amount: BigInt!
 }
 
 type WithdrawalExecutedEvent implements Event @entity {

--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -209,7 +209,7 @@ type Stake @entity {
   stakeDepositedEvents: [StakeDepositEvent!] @derivedFrom(field: "stake")
   withdrawalExecutedEvents: [WithdrawalExecutedEvent!] @derivedFrom(field: "stake")
   withdrawalInitiatedEvents: [WithdrawalInitiatedEvent!] @derivedFrom(field: "stake")
-  pendingWithdrawlQueue: [WithdrawalInitiatedEvent!] @derivedFrom(field: "stake")
+  pendingWithdrawlQueue: [WithdrawalInitiatedEvent!]
 }
 
 type AggregateActiveStake @entity {

--- a/subgraph/src/schema.gql
+++ b/subgraph/src/schema.gql
@@ -209,7 +209,7 @@ type Stake @entity {
   stakeDepositedEvents: [StakeDepositEvent!] @derivedFrom(field: "stake")
   withdrawalExecutedEvents: [WithdrawalExecutedEvent!] @derivedFrom(field: "stake")
   withdrawalInitiatedEvents: [WithdrawalInitiatedEvent!] @derivedFrom(field: "stake")
-  pendingWithdrawlQueue: [WithdrawalInitiatedEvent!]
+  pendingWithdrawalQueue: [WithdrawalInitiatedEvent!]
 }
 
 type AggregateActiveStake @entity {


### PR DESCRIPTION

<img width="1366" alt="Screen Shot 2023-04-25 at 7 24 44 AM" src="https://user-images.githubusercontent.com/40375385/234262360-5271db89-0868-4728-9d4d-52b6ac3760c4.png">



Withdraws work on the Forta Staking contract are a two step process:

1) A EOA calls `initiateWithdrawl` ([link to code](https://github.com/forta-network/forta-contracts/blob/master/contracts/components/staking/FortaStaking.sol#L364)). This method will move the amount of requested shares from active to inactive -> Adds those inactive shares to a time lock ->then fire a `WithdrawInitiated` event.

2) After the time lock the EOA can withdraw those shares by calling `withdraw`[link to code](https://github.com/forta-network/forta-contracts/blob/master/contracts/components/staking/FortaStaking.sol#L398). This will burn any inactive shares an EOA has on a given subject -> fire the `Withdraw` event.


**Note: `Withdraw` events don't tell have data on the amount withdrawn. Only that a withdrawal occurred.**

The changes this PR makes to the subgraph are the follow:

- Start to index the `WithdrawInitiated`
- Create a pendingWithdrawal queue on `Stake` entites so that we can do the accounting on correlating `WithdrawInitiated` events with `Withdrawal` events