### PR TITLE
FORTA-919: Set Up code coverage test

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,20 @@
+module.exports = {
+    skipFiles: [
+        'components/_old/agents/AgentRegistry_0_1_1.sol',
+        'components/_old/agents/AgentRegistry_0_1_2.sol',
+        'components/_old/agents/AgentRegistry_0_1_4.sol',
+        'components/_old/agents/AgentRegistry_0_1_5.sol',
+        'components/_old/dispatch/Dispatch_0_1_3.sol',
+        'components/_old/dispatch/Dispatch_0_1_4.sol',
+        'components/_old/scanners/ScannerNodeVersion_0_1_0.sol',
+        'components/_old/scanners/ScannerNodeVersion_0_1_1.sol',
+        'components/_old/scanners/ScannerRegistry_0_1_0.sol',
+        'components/_old/scanners/ScannerRegistry_0_1_1.sol',
+        'components/_old/scanners/ScannerRegistry_0_1_2.sol',
+        'components/_old/scanners/ScannerRegistry_0_1_3.sol',
+        'components/_old/staking/FortaStaking_0_1_0.sol',
+        'components/_old/staking/FortaStaking_0_1_1.sol',
+        'components/_old/staking/FortaStakingParameters_0_1_0.sol',
+        'components/_old/staking/FortaStakingParameters_0_1_1.sol'
+    ]
+  };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "semver": "^7.3.5",
     "solhint-plugin-prettier": "^0.0.5",
-    "solidity-coverage": "^0.7.17",
+    "solidity-coverage": "^0.8.2",
     "solidity-docgen": "^0.6.0-beta.8"
   }
 }


### PR DESCRIPTION
Updating to address test-to-code coverage point in the _DeFi Security_ report. Linear issue [FORTA-919](https://linear.app/forta-network/issue/FORTA-919/defi-security-report-fixes-test-to-code-coverage).

Updates:
* Update `solidity-coverage` in `package.json` since previous version had a bug.
* Create `.solcover.js` for code coverage config