### PR TITLE
Forta 1095 successfully parse active and inactive stake

### DIFF
--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -1,0 +1,20 @@
+# Forta Subgraph 
+The Forta subgraph is currently hosted on chainstack (both dev and production enviornments) and provides visibility to on-chain events around the forta protocol such as staking, rewards, node pools, etc.
+
+## Deployment
+
+We use [theGraph's cli](https://thegraph.com/docs/en/deploying/deploying-a-subgraph-to-studio/#deploying-a-subgraph-to-subgraph-studio) in our development and production github actions to deploy the Forta subgraph.
+
+### Dev Deployment
+
+The development deployment occurs on every pull request that is merged to master via a github action.
+
+Dev subgraph url: `https://polygon-mumbai.graph-eu.p2pify.com/6dbdbeb3262ca5fa43773df1e690bd53/forta-dev`
+
+### Production Deployment
+
+There are two production subgraphs which we follow a [blue/green deployment pattern](https://www.redhat.com/en/topics/devops/what-is-blue-green-deployment) via a github action.
+
+Forta-a subgraph url: `https://polygon-mainnet.graph-eu.p2pify.com/49e5eba171ac70bd41578331e4d65cfc/forta-a`
+
+Forta-b subgraph url: `https://polygon-mainnet.graph-eu.p2pify.com/62563b45923ea9d259c5c16d1f73f804/forta-b`

--- a/subgraph/src/datasources/FortaStaking.ts
+++ b/subgraph/src/datasources/FortaStaking.ts
@@ -159,14 +159,20 @@ function updateStake(
     sharesId.subject = _subjectId;
     sharesId.save();
   }
-  subject.activeStake = fortaStaking.activeStakeFor(
+
+  const activeStake = fortaStaking.try_activeStakeFor(
     _subjectType,
     _subject
   );
-  subject.inactiveStake = fortaStaking.inactiveStakeFor(
+
+  const inActiveStake = fortaStaking.try_inactiveStakeFor(
     _subjectType,
     _subject
   );
+
+  subject.activeStake = activeStake.reverted ? BigInt.fromI32(0) : activeStake.value;
+  subject.inactiveStake = inActiveStake.reverted ? BigInt.fromI32(0) : inActiveStake.value;
+  
   subject.activeShares = fortaStaking.totalShares(
     _subjectType,
     _subject


### PR DESCRIPTION

![image](https://github.com/forta-network/forta-contracts/assets/40375385/5a6c5a45-cedd-4ec8-9f31-fbaa05933e70)

There is a failure occurring in our production subgraphs which is causing an outage. Looks like one of the contract calls to our staking contracts is failing for a specific user when we try to index the subgraph.

This is causing the delegated pools table to not correctly render data 

![image](https://github.com/forta-network/forta-contracts/assets/40375385/abf1a2ce-c262-4e8e-84f5-a5791173670c)


