### PR TITLE
Add a variant of the Vesting wallet for updating the beneficiary

### DIFF
--- a/contracts/vesting/VestingWalletRecovery.sol
+++ b/contracts/vesting/VestingWalletRecovery.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+// See Forta Network License: https://github.com/forta-network/forta-contracts/blob/master/LICENSE.md
+
+pragma solidity ^0.8.9;
+
+import "./VestingWalletV1.sol";
+
+/**
+ * This contract is desigend for recovering the in case the beneficiary was lost.
+ */
+contract VestingWalletRecovery is VestingWalletV1 {
+    event BeneficiaryUpdate(address newBeneficiary);
+
+    function updateBeneficiary(address newBeneficiary) external onlyOwner {
+        _setBeneficiary(newBeneficiary);
+        emit BeneficiaryUpdate(newBeneficiary);
+    }
+}

--- a/contracts/vesting/VestingWalletRecovery.sol
+++ b/contracts/vesting/VestingWalletRecovery.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.9;
 import "./VestingWalletV1.sol";
 
 /**
- * This contract is designed for recovering the in case the beneficiary was lost.
+ * This contract is designed for recovery in case the beneficiary was lost.
  */
 contract VestingWalletRecovery is VestingWalletV1 {
     event BeneficiaryUpdate(address newBeneficiary);

--- a/contracts/vesting/VestingWalletRecovery.sol
+++ b/contracts/vesting/VestingWalletRecovery.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.9;
 import "./VestingWalletV1.sol";
 
 /**
- * This contract is desigend for recovering the in case the beneficiary was lost.
+ * This contract is designed for recovering the in case the beneficiary was lost.
  */
 contract VestingWalletRecovery is VestingWalletV1 {
     event BeneficiaryUpdate(address newBeneficiary);

--- a/contracts/vesting/VestingWalletRecoveryLight.sol
+++ b/contracts/vesting/VestingWalletRecoveryLight.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/StorageSlot.sol";
 
 /**
- * This contract is designed for recovering the in case the beneficiary was lost.
+ * This contract is designed for recovery in case the beneficiary was lost.
  */
 contract VestingWalletRecoveryLight {
     /// Storage

--- a/contracts/vesting/VestingWalletRecoveryLight.sol
+++ b/contracts/vesting/VestingWalletRecoveryLight.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: UNLICENSED
+// See Forta Network License: https://github.com/forta-network/forta-contracts/blob/master/LICENSE.md
+
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/utils/StorageSlot.sol";
+
+/**
+ * This contract is designed for recovering the in case the beneficiary was lost.
+ */
+contract VestingWalletRecoveryLight {
+    /// Storage
+    // Initializable
+    uint8 private _initialized;
+    bool private _initializing;
+    // ContextUpgradeable
+    uint256[50] private __gap_1;
+    // OwnableUpgradeable
+    address private _owner;
+    uint256[49] private __gap_2;
+    // UUPSUpgradeable
+    uint256[50] private __gap_3;
+    // ERC1967UpgradeUpgradeable
+    uint256[50] private __gap_4;
+    // VestingWallerV1
+    mapping (address => uint256) private _released;
+    address private _beneficiary;
+    uint256 private _start;
+    uint256 private _cliff;
+    uint256 private _duration;
+
+    /// Constants and Events
+    // ERC1967UpgradeUpgradeable
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    event Upgraded(address indexed implementation);
+
+    function changeOwnerAndUpgrade(address newBeneficiary, address newImplementation) external {
+        // change ownership
+        _beneficiary = newBeneficiary;
+
+        // ERC1967Upgrade._setImplementation
+        require(Address.isContract(newImplementation), "ERC1967: new implementation is not a contract");
+        StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;
+        emit Upgraded(newImplementation);
+    }
+
+    function proxiableUUID() external pure returns (bytes32) {
+        return _IMPLEMENTATION_SLOT;
+    }
+
+
+    function upgradeTo(address) external pure {
+        revert();
+    }
+
+    function upgradeToAndCall(address, bytes memory) external pure {
+        revert();
+    }
+}

--- a/contracts/vesting/VestingWalletV1.sol
+++ b/contracts/vesting/VestingWalletV1.sol
@@ -87,6 +87,10 @@ contract VestingWalletV1 is OwnableUpgradeable, UUPSUpgradeable {
         return _released[token];
     }
 
+    function _setBeneficiary(address newBeneficiary) internal {
+        _beneficiary = newBeneficiary;
+    }
+
     /**
     * @dev Release the tokens that have vested by the specified timestamp.
     */

--- a/test/vesting/VestingWallet.recovery.test.js
+++ b/test/vesting/VestingWallet.recovery.test.js
@@ -42,13 +42,23 @@ describe('VestingWallet ', function () {
                     unsafeAllow: 'delegatecall',
                 });
 
+                // restricted
                 await expect(this.vesting.connect(this.accounts.other).updateBeneficiary(this.accounts.other.address))
                     .to.be.revertedWith(`Ownable: caller is not the owner`);
 
+                // authorized
                 await expect(this.vesting.connect(this.accounts.admin).updateBeneficiary(this.accounts.user2.address))
                     .to.emit(this.vesting, 'BeneficiaryUpdate').withArgs(this.accounts.user2.address);
 
-                expect(await this.vesting.beneficiary()).to.be.equal(this.accounts.user2.address);
+                await Promise.all([this.vesting.start(), this.vesting.cliff(), this.vesting.duration(), this.vesting.beneficiary(), this.vesting.owner()]).then(
+                    ([start, cliff, duration, beneficiary, owner]) => {
+                        expect(start).to.be.equal(allocation.start);
+                        expect(cliff).to.be.equal(allocation.cliff);
+                        expect(duration).to.be.equal(allocation.duration);
+                        expect(beneficiary).to.be.equal(this.accounts.user2.address);
+                        expect(owner).to.be.equal(allocation.owner);
+                    }
+                );
             });
         });
     });

--- a/test/vesting/VestingWallet.recovery.test.js
+++ b/test/vesting/VestingWallet.recovery.test.js
@@ -1,0 +1,55 @@
+const hre = require('hardhat');
+const { ethers } = hre;
+const { expect } = require('chai');
+const { prepare, deployUpgradeable, performUpgrade, deploy, attach } = require('../fixture');
+const utils = require('../../scripts/utils');
+
+const allocation = {
+    start: utils.dateToTimestamp('2021-09-01T00:00:00Z'),
+    cliff: utils.durationToSeconds('1 year'),
+    duration: utils.durationToSeconds('4 years'),
+};
+
+describe('VestingWallet ', function () {
+    prepare();
+
+    describe('Vesting recovery', function () {
+        describe('vesting with admin', function () {
+            beforeEach(async function () {
+                allocation.beneficiary = this.accounts.user1.address;
+                allocation.owner = this.accounts.admin.address;
+
+                this.vesting = await deployUpgradeable(
+                    hre,
+                    'VestingWallet',
+                    'uups',
+                    [allocation.beneficiary, allocation.owner, allocation.start, allocation.cliff, allocation.duration],
+                    { unsafeAllow: 'delegatecall' }
+                );
+                await Promise.all([this.vesting.start(), this.vesting.cliff(), this.vesting.duration(), this.vesting.beneficiary(), this.vesting.owner()]).then(
+                    ([start, cliff, duration, beneficiary, owner]) => {
+                        expect(start).to.be.equal(allocation.start);
+                        expect(cliff).to.be.equal(allocation.cliff);
+                        expect(duration).to.be.equal(allocation.duration);
+                        expect(beneficiary).to.be.equal(allocation.beneficiary);
+                        expect(owner).to.be.equal(allocation.owner);
+                    }
+                );
+            });
+
+            it('perform recovery', async function () {
+                this.vesting = await performUpgrade(hre, this.vesting, 'VestingWalletRecovery', {
+                    unsafeAllow: 'delegatecall',
+                });
+
+                await expect(this.vesting.connect(this.accounts.other).updateBeneficiary(this.accounts.other.address))
+                    .to.be.revertedWith(`Ownable: caller is not the owner`);
+
+                await expect(this.vesting.connect(this.accounts.admin).updateBeneficiary(this.accounts.user2.address))
+                    .to.emit(this.vesting, 'BeneficiaryUpdate').withArgs(this.accounts.user2.address);
+
+                expect(await this.vesting.beneficiary()).to.be.equal(this.accounts.user2.address);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Some beneficiary of vesting wallets have lost access to their keys. This PR add a variant of the VestingWallet.

The admin can upgrade the wallet to that new variant and the use the new `updateBeneficiary` function to update the beneficiary address to a new value.